### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,8 @@ setup(
     author='jumblesale',
     author_email='',
     description='',
+    install_requires=[
+        'attrs>=18.1',
+        'inflection>=0.3',
+    ],
 )


### PR DESCRIPTION
Prior to this change all dependencies are managed in the Pipfile, however this does not work for libraries.
See: https://docs.pipenv.org/advanced/#pipfile-vs-setuppy