### PR TITLE
Make output pep8 compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+deps:
+	pipenv install --dev
+
+test: pep8 behave
+
+behave:
+	pipenv run behave test/e2e
+
+pep8:
+	pipenv run pycodestyle
+
+.PHONY: deps test behave pep8

--- a/Pipfile
+++ b/Pipfile
@@ -4,16 +4,19 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-flask = "*"
 attrs = "*"
-inflection = "*"
-twine = "*"
-sqlalchemy = "*"
-flask-sqlalchemy = "*"
-python-dateutil = "*"
-flask-restplus = "*"
 behave = "*"
+flask = "*"
+flask-marshmallow = "*"
+flask-restplus = "*"
+flask-sqlalchemy = "*"
+inflection = "*"
+marshmallow-sqlalchemy = "*"
+pycodestyle = "*"
 pyhamcrest = "*"
+python-dateutil = "*"
+sqlalchemy = "*"
+twine = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a527b650c23a5673493b6fe418c79c2a0fae64ccd454071d0d5e16c6462ef237"
+            "sha256": "8588b129746787be9eba7befcf6a6faa1e99c88b57fa02bd74c48ef9bbf8fd24"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -68,6 +68,14 @@
             "index": "pypi",
             "version": "==1.0.2"
         },
+        "flask-marshmallow": {
+            "hashes": [
+                "sha256:75c9d80f22af982b1e8ccec109d3b75c14bb5570602ae3705a4ff775badd2816",
+                "sha256:db7aff4130eb99fd05ab78fd2e2c58843ba0f208899aeb1c14aff9cd98ae8c80"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
+        },
         "flask-restplus": {
             "hashes": [
                 "sha256:1664401e61bcec4fdcfbfd25df81b233fe7388a6ae73c37b78918957609508b6"
@@ -123,6 +131,21 @@
             ],
             "version": "==1.0"
         },
+        "marshmallow": {
+            "hashes": [
+                "sha256:0f3776aa5b5405f6000c9304841abe6d4d708bb08207fc89a5ecd86622ec9e54",
+                "sha256:57a107cfd58e9ed52dd355c65444e983d064fdcf63214a487d7305a2d24680db"
+            ],
+            "version": "==2.15.4"
+        },
+        "marshmallow-sqlalchemy": {
+            "hashes": [
+                "sha256:32ff19350a8892b3e8dc954eeeac796576bb89356512f9e1ccd33da63f856930",
+                "sha256:755b16b64c0273fd8083dbe1e938dff0d49359c76d6238898c9082e3fc55368d"
+            ],
+            "index": "pypi",
+            "version": "==0.14.0"
+        },
         "parse": {
             "hashes": [
                 "sha256:c3cdf6206f22aeebfa00e5b954fcfea13d1b2dc271c75806b6025b94fb490939"
@@ -142,6 +165,14 @@
                 "sha256:a39076cb3eb34c333a0dd390b568e9e1e881c7bf2cc0aee12120636816f55aee"
             ],
             "version": "==1.4.2"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
         },
         "pyhamcrest": {
             "hashes": [
@@ -199,7 +230,7 @@
                 "sha256:536e5a0205b6401d8aaf04b21469949c178dbe3642e3c76d3bb494a83cb22a10",
                 "sha256:60bbaa6700e87a250f6abcbbd7ddb33243ad592240ba46afce5305b15b406fad"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.6' and python_version != '3.1.*'",
             "version": "==4.24.0"
         },
         "twine": {
@@ -215,7 +246,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.6' and python_version < '4' and python_version != '3.1.*'",
             "version": "==1.23"
         },
         "werkzeug": {

--- a/example.py
+++ b/example.py
@@ -1,11 +1,13 @@
 import dateutil
 
 from genyrator.entities.Column import create_column, create_identifier_column
-from genyrator.entities.Entity import create_entity, create_entity_from_type_dict, APIPath, APIPaths, create_api_path, \
-    create_additional_property
+from genyrator.entities.Entity import create_entity, create_entity_from_type_dict, APIPaths, create_api_path, create_additional_property
 from genyrator.entities.Relationship import create_relationship, JoinOption
-from genyrator.entities.Schema import Schema, create_schema
+from genyrator.entities.Schema import create_schema
 from genyrator.types import TypeOption
+
+from doggos import app, db
+from doggos.sqlalchemy.model import Dog, Owner, OwnerDogs
 
 treat_entity = create_entity(
     class_name='Treat',
@@ -82,9 +84,6 @@ schema = create_schema(
     entities=entities,
 )
 schema.write_files()
-
-from doggos import app, db
-from doggos.sqlalchemy.model import *
 
 if __name__ == '__main__':
     with app.app_context():

--- a/genyrator/__init__.py
+++ b/genyrator/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from genyrator.entities.Column import (
     Column,
     create_column,

--- a/genyrator/declarative/Property.py
+++ b/genyrator/declarative/Property.py
@@ -7,8 +7,8 @@ class Property(object):
     def __init__(
             self,
             type:       TypeOption,
-            nullable:   Optional[bool]=None,
-            identifier: Optional[bool]=None,
+            nullable:   Optional[bool] = None,
+            identifier: Optional[bool] = None,
     ):
         self.type =       type
         self.nullable =   nullable if nullable is not None else False

--- a/genyrator/entities/Column.py
+++ b/genyrator/entities/Column.py
@@ -38,7 +38,8 @@ def create_identifier_column(
         type_option:              TypeOption,
 ) -> IdentifierColumn:
     column: IdentifierColumn = create_column(
-        name=name, type_option=type_option, index=True, nullable=False, identifier=True,
+        name=name, type_option=type_option, index=True, nullable=False,
+        identifier=True,
     )
     return column
 
@@ -46,11 +47,11 @@ def create_identifier_column(
 def create_column(
         name:                     str,
         type_option:              TypeOption,
-        index:                    bool=False,
-        nullable:                 bool=True,
-        identifier:               bool=False,
-        foreign_key_relationship: Optional[str]=None,
-        display_name:             Optional[str]=None,
+        index:                    bool = False,
+        nullable:                 bool = True,
+        identifier:               bool = False,
+        foreign_key_relationship: Optional[str] = None,
+        display_name:             Optional[str] = None,
 ) -> Column:
     if identifier is True:
         constructor = IdentifierColumn

--- a/genyrator/entities/Entity.py
+++ b/genyrator/entities/Entity.py
@@ -89,23 +89,29 @@ class Entity(object):
     model_alias:           Optional[ImportAlias] =    attr.ib()
     additional_properties: List[AdditionalProperty] = attr.ib()
 
+    @property
+    def has_joined_entities(self):
+        return any(
+            len(api_path.joined_entities) > 0 for api_path in self.api_paths
+        )
+
 
 def create_entity(
-        class_name:            str,
-        identifier_column:     IdentifierColumn,
-        columns:               List[Column],
-        relationships:         List[Relationship]=list(),
-        uniques:               List[List[str]]=list(),
-        operations:            Optional[Set[OperationOption]]=None,
-        display_name:          Optional[str]=None,
-        table_name:            Optional[str]=None,
-        plural:                Optional[str]=None,
-        dashed_plural:         Optional[str]=None,
-        resource_namespace:    Optional[str]=None,
-        resource_path:         Optional[str]=None,
-        api_paths:             Optional[APIPaths]=None,
-        model_alias:           Optional[ImportAlias]=None,
-        additional_properties: Optional[List[AdditionalProperty]]=None
+        class_name:         str,
+        identifier_column:  IdentifierColumn,
+        columns:            List[Column],
+        relationships:      List[Relationship] = list(),
+        uniques:            List[List[str]] = list(),
+        operations:         Optional[Set[OperationOption]] = None,
+        display_name:       Optional[str] = None,
+        table_name:         Optional[str] = None,
+        plural:             Optional[str] = None,
+        dashed_plural:      Optional[str] = None,
+        resource_namespace: Optional[str] = None,
+        resource_path:      Optional[str] = None,
+        api_paths:          Optional[APIPaths] = None,
+        model_alias:        Optional[ImportAlias] = None,
+        additional_properties: Optional[List[AdditionalProperty]] = None
 ) -> Entity:
     operations = operations if operations is not None else all_operations
     python_name = pythonize(class_name)
@@ -148,15 +154,15 @@ def create_entity_from_type_dict(
         class_name:             str,
         identifier_column_name: str,
         type_dict:              Dict,
-        foreign_keys:           Set[Tuple[str, str]]=set(),
-        indexes:                Set[str]=set(),
-        operations:             Optional[Set[OperationOption]]=None,
-        relationships:          Optional[List[Relationship]]=None,
-        table_name:             Optional[str]=None,
-        uniques:                Optional[List[List[str]]]=None,
-        api_paths:              Optional[APIPaths]=None,
-        model_alias:            Optional[ImportAlias]=None,
-        additional_properties:  Optional[List[AdditionalProperty]]=None,
+        foreign_keys:           Set[Tuple[str, str]] = set(),
+        indexes:                Set[str] = set(),
+        operations:             Optional[Set[OperationOption]] = None,
+        relationships:          Optional[List[Relationship]] = None,
+        table_name:             Optional[str] = None,
+        uniques:                Optional[List[List[str]]] = None,
+        api_paths:              Optional[APIPaths] = None,
+        model_alias:            Optional[ImportAlias] = None,
+        additional_properties:  Optional[List[AdditionalProperty]] = None,
 ) -> Entity:
     columns = []
     foreign_keys_dict = {}
@@ -200,9 +206,9 @@ def create_entity_from_type_dict(
 def create_api_path(
         joined_entities: List[str],
         route:           str,
-        endpoint:        Optional[str]=None,
-        class_name:      Optional[str]=None,
-        property_name:   Optional[str]=None,
+        endpoint:        Optional[str] = None,
+        class_name:      Optional[str] = None,
+        property_name:   Optional[str] = None,
 ) -> APIPath:
     python_name = pythonize(joined_entities[-1])
     property_name = property_name if property_name else to_json_case(python_name)

--- a/genyrator/entities/Relationship.py
+++ b/genyrator/entities/Relationship.py
@@ -26,8 +26,8 @@ def create_relationship(
         nullable:                 bool,
         lazy:                     bool,
         join:                     JoinOption,
-        join_table:               Optional[str]=None,
-        property_name:            Optional[str]=None,
+        join_table:               Optional[str] = None,
+        property_name:            Optional[str] = None,
 ) -> Relationship:
     target_entity_python_name = pythonize(target_entity_class_name)
     return Relationship(

--- a/genyrator/entities/Schema.py
+++ b/genyrator/entities/Schema.py
@@ -40,10 +40,10 @@ class Schema(object):
 def create_schema(
         module_name:     str,
         entities:        List[Entity],
-        db_import_path:  Optional[str]=None,
-        api_name:        Optional[str]=None,
-        api_description: Optional[str]=None,
-        file_path:       Optional[List[str]]=None,
+        db_import_path:  Optional[str] = None,
+        api_name:        Optional[str] = None,
+        api_description: Optional[str] = None,
+        file_path:       Optional[List[str]] = None,
 ) -> Schema:
     db_import_path = db_import_path if db_import_path else '{}.sqlalchemy'.format(module_name)
     file_path =  file_path if file_path else [module_name]

--- a/genyrator/entities/Template.py
+++ b/genyrator/entities/Template.py
@@ -1,15 +1,14 @@
-import os
 from typing import List, Optional, NewType, Tuple, NamedTuple
 import attr
 from jinja2 import Template as JinjaTemplate, StrictUndefined
 
 from genyrator.entities.Entity import Entity
-from genyrator.path import get_root_path_list, create_relative_path
+from genyrator.path import create_relative_path
 
 OutPath = NewType('OutPath', Tuple[List[str], str])
 Import = NamedTuple('Import',
-    [('module_name', str),
-     ('imports',     List[str]), ])
+                    [('module_name', str),
+                     ('imports',     List[str]), ])
 
 
 @attr.s
@@ -34,8 +33,8 @@ class Template(object):
 
 def create_template(
         constructor,
-        template_path: Optional[List[str]]=None,
-        out_path:      Optional[OutPath]=None,
+        template_path: Optional[List[str]] = None,
+        out_path:      Optional[OutPath] = None,
         **kwargs,
 ) -> Template:
     relative_path = template_path[0:-1]

--- a/genyrator/path.py
+++ b/genyrator/path.py
@@ -10,6 +10,6 @@ def get_root_path_list() -> List[str]:
 
 def create_relative_path(paths: List[str]) -> str:
     return os.path.join(
-            *get_root_path_list(),
-            *paths,
-        )
+        *get_root_path_list(),
+        *paths,
+    )

--- a/genyrator/template_config.py
+++ b/genyrator/template_config.py
@@ -6,7 +6,7 @@ from genyrator.entities.Template import create_template
 TemplateConfig = NamedTuple('TemplateConfig', [
     ('root_files', List[Template.Template]),
     ('core',       List[Template.Template]),
-    ('db_init'  ,  List[Template.Template]),
+    ('db_init',    List[Template.Template]),
     ('db_models',  List[Template.Template]),
     ('resources',  List[Template.Template]), ])
 

--- a/genyrator/templates/config.j2
+++ b/genyrator/templates/config.j2
@@ -6,3 +6,4 @@ def config():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///test.db'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     return app
+

--- a/genyrator/templates/core/convert_dict.j2
+++ b/genyrator/templates/core/convert_dict.j2
@@ -16,7 +16,7 @@ def convert_dict_naming(in_dict: Dict, fn: Callable[[str], str]) -> Dict:
     return out_dict
 
 
-def convert_iterable_naming(in_list: Iterable, fn: Callable[[str], str]) -> List:
+def convert_iterable_naming(in_list: Iterable, fn: Callable[[str], str]) -> List:  # noqa: E501
     out_list = []
     for v in in_list:
         if type(v) is dict:

--- a/genyrator/templates/resources/__init__.j2
+++ b/genyrator/templates/resources/__init__.j2
@@ -13,4 +13,3 @@ api = Api(
 {% for entity in template.entities -%}
 api.add_namespace({{ entity.plural }}_api)
 {% endfor %}
-

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -9,14 +9,18 @@
     {%- set model_import = 'from ' + template.module_name + '.sqlalchemy.model import ' + entity.class_name -%}
 {%- endif -%}
 import json
-from flask import request, abort, json as flask_json, url_for
+from flask import request, abort, url_for
 from flask_restplus import Resource, fields, Namespace
+{% if entity.has_joined_entities %}
 from sqlalchemy.orm import joinedload
+{% endif %}
 from typing import Optional
-from {{ template.module_name }}.core.convert_dict import python_dict_to_json_dict, json_dict_to_python_dict
+from {{ template.module_name }}.core.convert_dict import (
+    python_dict_to_json_dict, json_dict_to_python_dict
+)
 from {{ template.db_import_path }} import db
 {{ model_import }}
-from {{ template.module_name }}.schema import *
+from {{ template.module_name }}.schema import {{ entity.class_name }}Schema
 from {{ template.module_name }}.sqlalchemy.model_to_dict import model_to_dict
 
 api = Namespace('{{ entity.resource_namespace }}',
@@ -37,18 +41,20 @@ api = Namespace('{{ entity.resource_namespace }}',
 {%- if entity.supports_put or entity.supports_get_one or entity.supports_delete_one %}
 
 
-@api.route('/{{ entity.dashed_name }}/<{{ entity.identifier_column.json_property_name }}>', endpoint='{{ entity.python_name }}_by_id')
+@api.route('/{{ entity.dashed_name }}/<{{ entity.identifier_column.json_property_name }}>', endpoint='{{ entity.python_name }}_by_id')  # noqa: E501
 class {{ entity.class_name }}Resource(Resource):  # type: ignore
     {%- if entity.supports_get_one %}
+
     @api.marshal_with({{ entity.python_name }}_model)
-    @api.doc(id='get-{{ entity.python_name }}-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
+    @api.doc(id='get-{{ entity.python_name }}-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     def get(self, {{ entity.identifier_column.json_property_name }}):  # type: ignore
-        {{ find_element_by_id() }}.first()
+        {{ find_element_by_id() }}.first()  # noqa: E501
         if result is None:
             abort(404)
         return python_dict_to_json_dict(model_to_dict(result))
-    {% endif -%}{# get_one method #}
-    {% if entity.supports_delete_one -%}
+    {%- endif -%}{# get_one method #}
+    {%- if entity.supports_delete_one %}
+
     @api.doc(id='delete-{{ entity.python_name }}-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, {{ entity.identifier_column.json_property_name }}):  # type: ignore
         result: Optional[{{ entity.class_name }}] = {{ entity.class_name }}.query.filter_by({# -#}
@@ -59,16 +65,16 @@ class {{ entity.class_name }}Resource(Resource):  # type: ignore
             abort(404)
         db.session.commit()
         return '', 204
-{# -#}
     {%- endif -%}{# delete_one method #}
     {%- if entity.supports_put %}
+
     @api.expect({{ entity.python_name }}_model, validate=False)
     def put(self, {{ entity.identifier_column.json_property_name }}):  # type: ignore
         data = json.loads(request.data)
         if type(data) is not dict:
             return abort(400)
 
-        {{ find_element_by_id() }}.first()
+        {{ find_element_by_id() }}.first()  # noqa: E501
 
         if '{{ entity.identifier_column.json_property_name }}' not in data:
             data['{{ entity.identifier_column.json_property_name }}'] = {# -#}
@@ -85,9 +91,9 @@ class {{ entity.class_name }}Resource(Resource):  # type: ignore
         db.session.add(marshmallow_result.data)
         db.session.commit()
         return '', 201
-{#  -#}
     {%- endif -%}{# put method #}
     {%- if entity.supports_patch %}
+
     @api.expect({{ entity.python_name }}_model, validate=False)
     def patch(self, {{ entity.identifier_column.json_property_name }}):  # type: ignore
         data = json.loads(request.data)
@@ -109,24 +115,31 @@ class {{ entity.class_name }}Resource(Resource):  # type: ignore
         db.session.add(result)
         db.session.commit()
     {%- endif -%}{# patch method #}
-{%- endif %}{# single class #}
+{%- endif -%}{# single class #}
 {%- if entity.supports_get_all or entity.supports_delete_all or entity.supports_post %}
 
 
-@api.route('/{{ entity.dashed_plural }}', endpoint='{{ entity.resource_namespace }}')
+@api.route('/{{ entity.dashed_plural }}', endpoint='{{ entity.resource_namespace }}')  # noqa: E501
 class Many{{ entity.class_name }}Resource(Resource):  # type: ignore
     {%- if entity.supports_get_all %}
+
     def get(self):
         {%- if entity.supports_get_one %}
         result = {{ entity.class_name }}.query.all()
-        urls = [url_for('{{ get_one_endpoint }}', {{ identifier_column.json_property_name }}=x.{{ identifier_column.python_name }}) for x in result]
+        urls = [
+            url_for(
+                '{{ get_one_endpoint }}',
+                {{ identifier_column.json_property_name }}=x.{{ identifier_column.python_name }}
+            )
+            for x in result
+        ]
         return {"links": urls}
         {%- else %}
         ...
         {%- endif %}
+    {%- endif -%}{# get_all method #}
+    {%- if entity.supports_post %}
 
-    {% endif -%}{# get_all method #}
-    {% if entity.supports_post %}
     def post(self):  # type: ignore
         ...
 {#-        data = json.loads(request.data)-#}
@@ -146,39 +159,39 @@ class Many{{ entity.class_name }}Resource(Resource):  # type: ignore
 {#-        db.session.add(marshmallow_result.data)-#}
 {#-        db.session.commit()-#}
 {#-        return '', 201-#}
-        {% endif %}{# support post #}
-{% endif %}{# many class #}
-
+        {%- endif -%}{# support post #}
+{%- endif -%}{# many class #}
 {%- if entity.api_paths -%}
-{% macro joinedload(relationship) -%}
+{%- macro joinedload(relationship) -%}
     joinedload('{{ relationship }}')
 {%- endmacro -%}
-{% for api_path in entity.api_paths %}
-@api.route('/{{ entity.dashed_name }}/<{{ entity.identifier_column.json_property_name }}>/{{ api_path.route }}', endpoint='{{ api_path.endpoint }}')
+{%- for api_path in entity.api_paths %}
+
+
+@api.route('/{{ entity.dashed_name }}/<{{ entity.identifier_column.json_property_name }}>/{{ api_path.route }}', endpoint='{{ api_path.endpoint }}')  # noqa: E501
 class {{ api_path.class_name }}(Resource):  # type: ignore
-    @api.doc(id='{{ api_path.endpoint }}', responses={401: 'Unauthorised', 404: 'Not Found'})
+    @api.doc(id='{{ api_path.endpoint }}', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     def get(self, {{ entity.identifier_column.json_property_name }}):  # type: ignore
         result: Optional[{{ entity.class_name }}] = {{ entity.class_name }} \
             .query \
-            .options({#  -#}
+            .options(
     {%- set sep = joiner('.') -%}
-    {%- for entity in api_path.joined_entities -%}
-        {{ sep() }}{{ joinedload(entity) }}
-    {%- endfor -%}
+    {%- for entity in api_path.joined_entities %}
+                {{ sep() }}{{ joinedload(entity) }}
+    {%- endfor %}
             ) \
             .filter_by({# -#}
                 {{ entity.identifier_column.python_name }}={# -#}
                 {{ entity.identifier_column.json_property_name }}{# -#}
             ) \
-            .first()
+            .first()  # noqa: E501
         if result is None:
             abort(404)
         return python_dict_to_json_dict(model_to_dict(result, ['{#  -#}
     {%- set sep = joiner("', '") -%}
     {%- for entity in api_path.joined_entities -%}
         {{ sep() }}{{ entity }}
-    {%- endfor %}']))
-
-
-{% endfor -%}
+    {%- endfor %}']))  # noqa: E501
+{%- endfor -%}
 {%- endif %}
+

--- a/genyrator/templates/resources/restplus_model.j2
+++ b/genyrator/templates/resources/restplus_model.j2
@@ -3,6 +3,6 @@
     '{{ column.json_property_name }}': fields.{{ column.restplus_type.value }}(),
 {%- endfor %}
 {%- for api_path in template.entity.api_paths %}
-    '{{ api_path.property_name }}': fields.Url('{{ api_path.endpoint }}'),
+    '{{ api_path.property_name }}': fields.Url('{{ api_path.endpoint }}'),  # noqa: E501
 {%- endfor %}
 })

--- a/genyrator/templates/schema.j2
+++ b/genyrator/templates/schema.j2
@@ -1,10 +1,13 @@
 from marshmallow_sqlalchemy import ModelSchema
-from {{ template.module_name }}.sqlalchemy.model import *
-
+from {{ template.module_name }}.sqlalchemy.model import (
 {% for entity in template.entities %}
+    {{ entity.class_name }},
+{% endfor %}
+)
+{% for entity in template.entities %}
+
 class {{ entity.class_name }}Schema(ModelSchema):
     class Meta:
         include_fk = True
         model = {{ entity.class_name }}
-
 {% endfor %}

--- a/genyrator/templates/sqlalchemy/model/__init__.j2
+++ b/genyrator/templates/sqlalchemy/model/__init__.j2
@@ -1,3 +1,4 @@
+# flake8: noqa
 {% for import in template.imports -%}
 from {{ template.module_name }}.sqlalchemy.model.{{ import.module_name }} import {% for import in import.imports %}{{ import }}{% endfor %}
 {% endfor %}

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -1,5 +1,4 @@
 from {{ template.db_import_path }} import db
-from datetime import datetime
 from sqlalchemy import UniqueConstraint
 
 {%- macro pad(name) -%}
@@ -16,21 +15,22 @@ class {{ template.entity.class_name }}(db.Model):  # type: ignore
     {{ property.python_name }} = {{ property.value }}
     {%- endfor %}
 {% endif %}
-    id ={{ pad('id') }} db.Column(db.Integer, primary_key=True)
+    id ={{ pad('id') }} db.Column(db.Integer, primary_key=True)  # noqa: E501
 {%- for column in template.entity.columns %}
     {{ column.python_name }} ={{ pad(column.python_name) }} db.Column(db.{{ column.sqlalchemy_type.value }}
     {%- if column.relationship is defined %}, db.ForeignKey('{{ column.relationship }}'){% endif %}
     {%- if column.index %}, index=True{% endif %}{# -#}
-    , nullable={{ column.nullable | string }})
+    , nullable={{ column.nullable | string }})  # noqa: E501
 {%- endfor %}
 {%- for relationship in template.entity.relationships %}
-    {{ relationship.property_name }} ={{ pad(relationship.property_name) }} db.relationship('{{ relationship.target_entity_class_name }}', {# -#}
-    lazy={{ relationship.lazy | string }}, uselist={{ relationship.join.value == 'to_many' | string }}{# -#}
-    {%- if relationship.join_table %}, secondary='{{ relationship.join_table }}'{% endif -%}{# -#}
-)
+    {{ relationship.property_name }} ={{ pad(relationship.property_name) }} db.relationship(
+        '{{ relationship.target_entity_class_name }}',
+        lazy={{ relationship.lazy | string }},
+        uselist={{ relationship.join.value == 'to_many' | string }}{% if relationship.join_table %},
+        secondary='{{ relationship.join_table }}'{% endif %}
+    )
 {%- endfor %}
 {%- if template.entity.uniques %}
 
     __table_args__ = {{ template.entity.table_args }}
 {% endif %}
-

--- a/genyrator/templates/sqlalchemy/model_to_dict.j2
+++ b/genyrator/templates/sqlalchemy/model_to_dict.j2
@@ -24,9 +24,12 @@ def model_to_dict(model: DeclarativeMeta, paths=list()):
     next_key = next_path
     if type(next_relationship) is InstrumentedList:
         serialized_data[next_key] = [
-            python_dict_to_json_dict(model_to_dict(nr, paths[1:])) for nr in next_relationship
+            python_dict_to_json_dict(model_to_dict(nr, paths[1:]))
+            for nr in next_relationship
         ]
     else:
-        serialized_data[next_key] = python_dict_to_json_dict(model_to_dict(next_relationship, paths[1:]))
+        serialized_data[next_key] = python_dict_to_json_dict(
+            model_to_dict(next_relationship, paths[1:])
+        )
     return serialized_data
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
-[pep8]
-ignore = E222
+[pycodestyle]
+ignore = E222, E241
 max-line-length = 160

--- a/test/e2e/environment.py
+++ b/test/e2e/environment.py
@@ -1,6 +1,5 @@
 import os
 import glob
-import shutil
 
 from genyrator.path import get_root_path_list
 

--- a/test/e2e/steps/steps.py
+++ b/test/e2e/steps/steps.py
@@ -4,7 +4,7 @@ import random
 import string
 from functools import partial
 
-from behave import *
+from behave import step, given, then, when
 from typing import List, Any, Dict, Optional
 
 from flask.testing import FlaskClient
@@ -14,8 +14,9 @@ from genyrator import (
     Entity, create_entity, Column, create_column, create_identifier_column,
     string_to_type_option,
 )
-from genyrator.entities.Entity import all_operations as all_entity_operations, OperationOption, \
+from genyrator.entities.Entity import (
     string_to_operation_option, all_operations
+)
 from genyrator.entities.Column import IdentifierColumn
 from genyrator.entities.Schema import create_schema, Schema
 
@@ -32,7 +33,11 @@ def _create_test_entity(columns: List[Column], identifier_column: IdentifierColu
     )
 
 
-def _make_request(client: FlaskClient, endpoint: str, method: str, parameters: Optional[str]=None, data: Optional[Dict]=None):
+def _make_request(
+    client: FlaskClient, endpoint: str, method: str,
+    parameters: Optional[str] = None,
+    data: Optional[Dict] = None
+):
     if parameters is not None:
         parameters = '&'.join(parameters.split(','))
         endpoint = '?'.join([endpoint, parameters])
@@ -42,7 +47,7 @@ def _make_request(client: FlaskClient, endpoint: str, method: str, parameters: O
     return method()
 
 
-def _create_schema(context: Any, module_name: Optional[str]=None):
+def _create_schema(context: Any, module_name: Optional[str] = None):
     entity_name = context.entity_name if hasattr(context, 'entity_name') else None
     operations = context.operations if hasattr(context, 'operations') else all_operations
     entity = create_entity(


### PR DESCRIPTION
Add pycodestyle and a Makefile

I have gone with pycodestyle rather than flake8 as the currently released version of flake8 (3.5.0) depends on an older version of pycodestyle (<2.4.0) which doesn't have a number of fixes around PEP 484 type hinting syntax.