### PR TITLE
Do not double add identifier column as unique

### DIFF
--- a/genyrator/entities/Entity.py
+++ b/genyrator/entities/Entity.py
@@ -116,7 +116,8 @@ def create_entity(
     operations = operations if operations is not None else all_operations
     python_name = pythonize(class_name)
     columns = [identifier_column, *columns]
-    uniques = [[identifier_column.python_name], *uniques]
+    if [identifier_column.python_name] not in uniques:
+        uniques = [[identifier_column.python_name], *uniques]
     max_property_length = _calculate_max_property_length(
         identifier_column, columns, relationships
     )

--- a/test/spec/generator/entities/Entity_spec.py
+++ b/test/spec/generator/entities/Entity_spec.py
@@ -1,0 +1,34 @@
+from mamba import description, it
+from expects import expect, equal
+
+from genyrator.entities.Entity import create_entity
+from genyrator.entities.Column import create_column, create_identifier_column
+from genyrator.types import TypeOption
+
+
+with description('create_entity'):
+    with it('adds unique on identifier if it does not exist'):
+        entity = create_entity(
+            'Test',
+            create_identifier_column('test_id', TypeOption.string),
+            [
+                create_column('id', TypeOption.int, index=True, nullable=False),
+                create_column('name', TypeOption.string, index=False, nullable=True),
+            ],
+            uniques=[],
+        )
+
+        expect(entity.uniques).to(equal([['test_id']]))
+
+    with it('does not add unique on identifier if it does exist'):
+        entity = create_entity(
+            'Test',
+            create_identifier_column('test_id', TypeOption.string),
+            [
+                create_column('id', TypeOption.int, index=True, nullable=False),
+                create_column('name', TypeOption.string, index=False, nullable=True),
+            ],
+            uniques=[['test_id']],
+        )
+
+        expect(entity.uniques).to(equal([['test_id']]))


### PR DESCRIPTION
If the identifier column is already present in the uniques list do not add it again.