### PR TITLE
Add multi path relationships between entities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 deps:
 	pipenv install --dev
 
-test: pep8 behave
+test: pep8 mamba behave
 
 behave:
 	pipenv run behave --tags=-skip test/e2e 
+
+mamba:
+	pipenv run mamba test
 
 pep8:
 	pipenv run pycodestyle

--- a/bookshop.py
+++ b/bookshop.py
@@ -28,6 +28,14 @@ book_entity = create_entity(
             ),
         ),
         create_column(
+            name='collaborator_id', type_option=TypeOption.int,
+            nullable=True,
+            foreign_key_relationship=ForeignKeyRelationship(
+                target_entity='author',
+                target_entity_identifier_column_type=TypeOption.UUID,
+            ),
+        ),
+        create_column(
             name='published', type_option=TypeOption.date,
             # alias='date_published',
         ),
@@ -41,7 +49,19 @@ book_entity = create_entity(
             source_identifier_column_name='book_id',
             target_identifier_column_name='author_id',
             target_entity_class_name='Author',
+            property_name='author',
             nullable=False,
+            lazy=False,
+            join=JoinOption.to_one,
+        ),
+        create_relationship(
+            source_foreign_key_column_name='collaborator_id',
+            source_identifier_column_name='book_id',
+            target_identifier_column_name='author_id',
+            target_entity_class_name='Author',
+            key_alias_in_json='collaborator_id',
+            property_name='collaborator',
+            nullable=True,
             lazy=False,
             join=JoinOption.to_one,
         ),
@@ -88,6 +108,22 @@ author_entity = create_entity(
             name='name', type_option=TypeOption.string,
             index=True, nullable=False,
         ),
+        create_column(
+            name='favourite_author_id', type_option=TypeOption.int,
+            # TODO: need to be able to identify target foreign key
+            foreign_key_relationship=ForeignKeyRelationship(
+                target_entity='author',
+                target_entity_identifier_column_type=TypeOption.UUID,
+            ),
+        ),
+        create_column(
+            name='hated_author_id', type_option=TypeOption.int,
+            # TODO: need to be able to identify target foreign key
+            foreign_key_relationship=ForeignKeyRelationship(
+                target_entity='author',
+                target_entity_identifier_column_type=TypeOption.UUID,
+            ),
+        ),
     ],
     relationships=[
         create_relationship(
@@ -95,6 +131,7 @@ author_entity = create_entity(
             source_foreign_key_column_name=None,
             source_identifier_column_name='author_id',
             target_identifier_column_name='book_id',
+            target_foreign_key_column_name='author_id',
             nullable=False,
             lazy=False,
             join=JoinOption.to_many,
@@ -105,10 +142,22 @@ author_entity = create_entity(
             source_foreign_key_column_name=None,
             source_identifier_column_name='author_id',
             target_identifier_column_name='book_id',
+            target_foreign_key_column_name='author_id',
             nullable=False,
             lazy=False,
             join=JoinOption.to_one,
             property_name='favourite_book',
+        ),
+        create_relationship(  # TODO: we need target_foreign_key_column_name
+            target_entity_class_name='Book',
+            source_foreign_key_column_name=None,
+            source_identifier_column_name='author_id',
+            target_identifier_column_name='book_id',
+            target_foreign_key_column_name='collaborator_id',
+            nullable=True,
+            lazy=False,
+            join=JoinOption.to_many,
+            property_name='collaborations',
         ),
     ],
     api_paths=[

--- a/bookshop/domain/Author.py
+++ b/bookshop/domain/Author.py
@@ -3,6 +3,7 @@ from bookshop.domain.types import DomainModel, Relationship
 
 from bookshop.sqlalchemy.model.Book import Book
 from bookshop.sqlalchemy.model.Book import Book
+from bookshop.sqlalchemy.model.Book import Book
 
 author = DomainModel(
     external_identifier_map={
@@ -19,10 +20,13 @@ author = DomainModel(
     relationship_keys=[
         'books',
         'favourite_book',
+        'collaborations',
     ],
     property_keys=[
         'author_id',
         'name',
+        'favourite_author_id',
+        'hated_author_id',
     ],
     json_translation_map={
         'author_id': 'id',
@@ -31,5 +35,6 @@ author = DomainModel(
     eager_relationships=[
         'books',
         'favourite_book',
+        'collaborations',
     ],
 )

--- a/bookshop/domain/Book.py
+++ b/bookshop/domain/Book.py
@@ -2,6 +2,7 @@ from bookshop.domain.types import DomainModel, Relationship
 
 
 from bookshop.sqlalchemy.model.Author import Author
+from bookshop.sqlalchemy.model.Author import Author
 from bookshop.sqlalchemy.model.Review import Review
 from bookshop.sqlalchemy.model.Genre import Genre
 
@@ -15,10 +16,19 @@ book = DomainModel(
             lazy=False,
             nullable=False,
         ),
+        'collaborator_id': Relationship(
+            sqlalchemy_model_class=Author,
+            target_name='author',
+            target_identifier_column='author_id',
+            source_foreign_key_column='collaborator_id',
+            lazy=False,
+            nullable=True,
+        ),
     },
     identifier_column_name='book_id',
     relationship_keys=[
         'author',
+        'collaborator',
         'reviews',
         'genre',
     ],
@@ -27,15 +37,18 @@ book = DomainModel(
         'name',
         'rating',
         'author_id',
+        'collaborator_id',
         'published',
         'created',
     ],
     json_translation_map={
         'book_id': 'id',
         'author_id': 'author',
+        'collaborator_id': 'collaborator',
     },
     eager_relationships=[
         'author',
+        'collaborator',
         'genre',
     ],
 )

--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -25,6 +25,8 @@ api = Namespace('authors',
 author_model = api.model('Author', {
     'id': fields.String(attribute='authorId'),
     'name': fields.String(),
+    'favouriteAuthorId': fields.String(),
+    'hatedAuthorId': fields.String(),
 })
 
 author_schema = AuthorSchema()

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -27,6 +27,7 @@ book_model = api.model('Book', {
     'name': fields.String(),
     'rating': fields.Float(),
     'authorId': fields.String(),
+    'collaboratorId': fields.String(),
     'published': fields.Date(),
     'created': fields.DateTime(),
 })

--- a/bookshop/sqlalchemy/model/Author.py
+++ b/bookshop/sqlalchemy/model/Author.py
@@ -6,18 +6,28 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class Author(db.Model):  # type: ignore
-    id =             db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
-    author_id =      db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
-    name =           db.Column(db.String, index=True, nullable=False)  # noqa: E501
-    books =          db.relationship(
+    id =                  db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
+    author_id =           db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
+    name =                db.Column(db.String, index=True, nullable=False)  # noqa: E501
+    favourite_author_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
+    hated_author_id =     db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
+    books =               db.relationship(
         'Book',
         lazy=False,
         uselist=True,
+        foreign_keys='Book.author_id',
     )
-    favourite_book = db.relationship(
+    favourite_book =      db.relationship(
         'Book',
         lazy=False,
         uselist=False,
+        foreign_keys='Book.author_id',
+    )
+    collaborations =      db.relationship(
+        'Book',
+        lazy=False,
+        uselist=True,
+        foreign_keys='Book.collaborator_id',
     )
 
     __table_args__ = (UniqueConstraint('author_id', ), )

--- a/bookshop/sqlalchemy/model/Book.py
+++ b/bookshop/sqlalchemy/model/Book.py
@@ -6,25 +6,32 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class Book(db.Model):  # type: ignore
-    id =        db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
-    book_id =   db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
-    name =      db.Column(db.String, index=True, nullable=False)  # noqa: E501
-    rating =    db.Column(db.Float, index=True, nullable=False)  # noqa: E501
-    author_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
-    published = db.Column(db.Date, nullable=True)  # noqa: E501
-    created =   db.Column(db.DateTime, nullable=True)  # noqa: E501
-    author =    db.relationship(
+    id =              db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
+    book_id =         db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
+    name =            db.Column(db.String, index=True, nullable=False)  # noqa: E501
+    rating =          db.Column(db.Float, index=True, nullable=False)  # noqa: E501
+    author_id =       db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
+    collaborator_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
+    published =       db.Column(db.Date, nullable=True)  # noqa: E501
+    created =         db.Column(db.DateTime, nullable=True)  # noqa: E501
+    author =          db.relationship(
         'Author',
         lazy=False,
         uselist=False,
         foreign_keys=[author_id],
     )
-    reviews =   db.relationship(
+    collaborator =    db.relationship(
+        'Author',
+        lazy=False,
+        uselist=False,
+        foreign_keys=[collaborator_id],
+    )
+    reviews =         db.relationship(
         'Review',
         lazy=True,
         uselist=True,
     )
-    genre =     db.relationship(
+    genre =           db.relationship(
         'Genre',
         lazy=False,
         uselist=False,

--- a/genyrator/entities/Column.py
+++ b/genyrator/entities/Column.py
@@ -51,6 +51,27 @@ def create_column(
         alias:                    Optional[str] = None,
         foreign_key_relationship: Optional[ForeignKeyRelationship] = None,
 ) -> Union[Column, ForeignKey]:
+    """Return a column to be attached to an entity
+
+    Args:
+        name:        The property name on the SQLAlchemy model
+
+        type_option: The type of the column.
+
+        index:       Whether to create a database index for the column.
+
+        nullable:    Whether to allow the column to be nullable in the database.
+
+        identifier:  If set to True all other args will be ignored and this will
+                     created as an identifier column. See: create_identifier_column
+
+        display_name: Human readable name intended for use in UIs.
+
+        alias:        Column name to be used the database.
+
+        foreign_key_relationship: The entity this column relates. If this is not
+                                  None the result will be a `ForeignKey`.
+    """
     if identifier is True:
         constructor = IdentifierColumn
     elif foreign_key_relationship is not None:
@@ -86,6 +107,17 @@ def create_identifier_column(
         name:        str,
         type_option: TypeOption,
 ) -> IdentifierColumn:
+    """Return an identifier column for an entity
+
+    The identifier column is not the database primary key for the table.
+    The primary key is auto-generated and is always called `id`.
+
+    This identifier column is always unique, indexed and non-nullable.
+
+    Args:
+        name:        The property name on the SQLAlchemy model.
+        type_option: The type of the column.
+    """
     column: IdentifierColumn = create_column(
         name=name, type_option=type_option, index=True, nullable=False,
         identifier=True,

--- a/genyrator/entities/Entity.py
+++ b/genyrator/entities/Entity.py
@@ -112,6 +112,55 @@ def create_entity(
         model_alias:        Optional[ImportAlias] = None,
         additional_properties: Optional[List[AdditionalProperty]] = None
 ) -> Entity:
+    """Return a fully configured Entity
+
+    The returned Entity is configured with columns and relationships.
+
+    Args:
+        class_name:          The class name (eg BookClub) used for the SQLAlchemy
+                             and RESTPlus models
+
+        identifier_column:   The column used to identify the entity in the URL. Note;
+                             this is not the primary key of the SQLAlchemy model and therefore
+                             is not used for joins.
+
+        columns:             All columns except for the internally generated primary key.
+                             This must includes the identifier column and any columns
+                             required for relationships.
+
+        relationships:       The relationships between entities. This means just SQLAlchemy
+                             relationships unless the relationship is non-lazy in which case
+                             it will also appear in the JSON response.
+
+        uniques:             A list of list of column names that require unique indexes.
+                             The identifier column does not need to appear in here.
+
+        operations:          HTTP actions which should be generated for this entity.
+
+        display_name:        Human readable name (eg Book Club). Has sensible default.
+
+        table_name:          The SQLAlchemy table. Has sensible default.
+
+        plural:              The plural form of the entity name used in method names
+                             (eg book_clubs). Has sensible default.
+
+        dashed_plural:       The plural form of the entity name used in URIs and
+                             RESTPlus resource IDs (eg book-clubs). Has sensible default.
+
+        resource_namespace:  RESTPlus namespace resource name for entity (eg BookClub). Has sensible default.
+
+        resource_path:       RESTPlus namespace path. Has sensible default.
+
+        api_paths:           List of class names for which RESTPlus routes should
+                             be created. A relationship must exist for the path.
+                             This is only needed for lazy relationships.
+
+        model_alias:         Override the SQLAlchemy model used in the RESTPlus routes.
+                             Use this if you want to extend the generated SQLAlchemy model.
+
+        additional_properties: Key value pairs to be added to the SQLAlchemy model.
+                               They will end up in the model as `key = value`.
+    """
     operations = operations if operations is not None else all_operations
     python_name = pythonize(class_name)
     columns = [identifier_column, *columns]

--- a/genyrator/entities/Relationship.py
+++ b/genyrator/entities/Relationship.py
@@ -14,6 +14,7 @@ class Relationship(object):
     python_name:                    str =           attr.ib()
     target_entity_class_name:       str =           attr.ib()
     target_entity_python_name:      str =           attr.ib()
+    target_foreign_key_column_name: Optional[str] = attr.ib()
     source_foreign_key_column_name: Optional[str] = attr.ib()
     source_identifier_column_name:  str =           attr.ib()
     property_name:                  str =           attr.ib()
@@ -40,17 +41,56 @@ def create_relationship(
         lazy:                           bool,
         join:                           JoinOption,
         source_identifier_column_name:  str,
+        *,
         source_foreign_key_column_name: Optional[str] = None,
         key_alias_in_json:              Optional[str] = None,
         join_table:                     Optional[str] = None,
         target_identifier_column_name:  Optional[str] = None,
+        target_foreign_key_column_name: Optional[str] = None,
         property_name:                  Optional[str] = None,
 ) -> Relationship:
+    """Return a relationship between two entities
+
+    Args:
+        target_entity_class_name:  The entity this relationship is pointing to
+                                   (ie. not the entity it is defined on).
+
+        nullable: Early validation for whether the target column is nullable.
+
+        lazy: If False the target entity is embedded in the JSON response.
+
+        join: Whether the relationship is 1-to-1 or 1-to-many. If 1-to-1 the property
+              will be scalar, if 1-to-many it will be a list.
+
+        source_identifier_column_name: The identifier column for the entity
+                                       this relationship starts from. This is
+                                       *not* the join key.
+
+        source_foreign_key_column_name: The foreign key property on the entity
+                                        this relationship starts from. This will
+                                        be None for 1-to-many relationship.
+
+        key_alias_in_json: The name used for this relationship when it appears in JSON.
+                           This needs to be unique for a model.
+                           Has sensible default.
+
+        join_table: The table name to join through to the target entity.
+                    This is usually only needed for many-to-many relationships.
+
+        target_identifier_column_name: The identifier column of the target entity. (deprecated)
+
+        target_foreign_key_column_name: The column name of the foreign key on the
+                                        target model. This is usually only needed if
+                                        there are multiple routes to the other entity.
+
+        property_name: The property name used on the SQLAlchemy model.
+    """
     target_entity_python_name = pythonize(target_entity_class_name)
     relationship = Relationship(
         python_name=target_entity_python_name,
         target_entity_class_name=target_entity_class_name,
         target_entity_python_name=target_entity_python_name,
+        target_foreign_key_column_name=target_foreign_key_column_name,
         source_identifier_column_name=source_identifier_column_name,
         source_foreign_key_column_name=source_foreign_key_column_name,
         property_name=property_name if property_name is not None else target_entity_python_name,

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -34,6 +34,8 @@ class {{ template.entity.class_name }}(db.Model):  # type: ignore
         uselist={{ relationship.join.value == 'to_many' | string }},
     {%- if relationship.source_foreign_key_column_name %}
         foreign_keys=[{{ relationship.source_foreign_key_column_name }}],
+    {%- elif relationship.target_foreign_key_column_name %}
+        foreign_keys='{{ relationship.target_entity_class_name }}.{{ relationship.target_foreign_key_column_name }}',
     {%- endif %}
     {%- if relationship.__class__.__name__ == 'RelationshipWithJoinTable' %}
         secondary='{{ relationship.join_table }}',

--- a/test/e2e/features/sqlalchemy_relationships.feature
+++ b/test/e2e/features/sqlalchemy_relationships.feature
@@ -1,0 +1,27 @@
+Feature: SQLAlchemy relationships
+
+  Background:
+    Given I have the example "bookshop" application
+
+  Scenario: Following a 1-to-many relationship
+    Given I put an example "author" entity
+      And I put a book entity with a relationship to that author
+      And I put a book entity with a relationship to that author
+     When I get that "author" SQLAlchemy model
+     Then "sql_author.books" should have "2" items in it
+  
+  Scenario: Following a many-to-1 relationship
+    Given I put an example "author" entity
+      And I put a book entity with a relationship to that author
+      And I put a book entity with a relationship to that author
+     When I get that "book" SQLAlchemy model
+     Then "sql_book.author" should be that author
+      And "sql_book.collaborator" should be None
+
+  Scenario: Following other many-to-1 relationship
+    Given I put an example "author" entity
+      And I put a book entity with a relationship to that author
+      And I also put a collaborator relationship to that author
+     When I get that "book" SQLAlchemy model
+     Then "sql_book.author" should be that author
+      And "sql_book.collaborator" should be that author


### PR DESCRIPTION
This adds support for defining a relationship between two entities where the join path cannot be determined by SQLAlchemy without some additional help. This happens when there is more than one possible join path between two models.

This change does not include support for defining multiple relationships back on the same entity. 