### PR TITLE
Add multi path self referencing relationships

### DIFF
--- a/bookshop.py
+++ b/bookshop.py
@@ -110,7 +110,6 @@ author_entity = create_entity(
         ),
         create_column(
             name='favourite_author_id', type_option=TypeOption.int,
-            # TODO: need to be able to identify target foreign key
             foreign_key_relationship=ForeignKeyRelationship(
                 target_entity='author',
                 target_entity_identifier_column_type=TypeOption.UUID,
@@ -118,7 +117,6 @@ author_entity = create_entity(
         ),
         create_column(
             name='hated_author_id', type_option=TypeOption.int,
-            # TODO: need to be able to identify target foreign key
             foreign_key_relationship=ForeignKeyRelationship(
                 target_entity='author',
                 target_entity_identifier_column_type=TypeOption.UUID,
@@ -148,7 +146,7 @@ author_entity = create_entity(
             join=JoinOption.to_one,
             property_name='favourite_book',
         ),
-        create_relationship(  # TODO: we need target_foreign_key_column_name
+        create_relationship(
             target_entity_class_name='Book',
             source_foreign_key_column_name=None,
             source_identifier_column_name='author_id',
@@ -158,6 +156,52 @@ author_entity = create_entity(
             lazy=False,
             join=JoinOption.to_many,
             property_name='collaborations',
+        ),
+        create_relationship(
+            target_entity_class_name='Author',
+            source_foreign_key_column_name=None,
+            source_identifier_column_name='author_id',
+            target_identifier_column_name='author_id',
+            target_foreign_key_column_name='favourite_author_id',
+            nullable=True,
+            lazy=True,
+            join=JoinOption.to_many,
+            property_name='favourite_of',
+        ),
+        create_relationship(
+            target_entity_class_name='Author',
+            source_foreign_key_column_name='favourite_author_id',
+            source_identifier_column_name='author_id',
+            target_identifier_column_name='author_id',
+            target_foreign_key_column_name=None,
+            key_alias_in_json='favourite_author_id',
+            nullable=True,
+            lazy=True,
+            join=JoinOption.to_one,
+            property_name='favourite_author',
+        ),
+        create_relationship(
+            target_entity_class_name='Author',
+            source_foreign_key_column_name=None,
+            source_identifier_column_name='author_id',
+            target_identifier_column_name='author_id',
+            target_foreign_key_column_name='hated_author_id',
+            nullable=True,
+            lazy=True,
+            join=JoinOption.to_many,
+            property_name='hated_by',
+        ),
+        create_relationship(
+            target_entity_class_name='Author',
+            source_foreign_key_column_name='hated_author_id',
+            source_identifier_column_name='author_id',
+            target_identifier_column_name='author_id',
+            target_foreign_key_column_name=None,
+            key_alias_in_json='hated_author_id',
+            nullable=True,
+            lazy=True,
+            join=JoinOption.to_one,
+            property_name='hated_author',
         ),
     ],
     api_paths=[

--- a/bookshop/domain/Author.py
+++ b/bookshop/domain/Author.py
@@ -2,8 +2,7 @@ from bookshop.domain.types import DomainModel, Relationship
 
 
 from bookshop.sqlalchemy.model.Book import Book
-from bookshop.sqlalchemy.model.Book import Book
-from bookshop.sqlalchemy.model.Book import Book
+from bookshop.sqlalchemy.model.Author import Author
 
 author = DomainModel(
     external_identifier_map={
@@ -15,12 +14,32 @@ author = DomainModel(
             lazy=False,
             nullable=False,
         ),
+        'favourite_author_id': Relationship(
+            sqlalchemy_model_class=Author,
+            target_name='author',
+            target_identifier_column='author_id',
+            source_foreign_key_column='favourite_author_id',
+            lazy=True,
+            nullable=True,
+        ),
+        'hated_author_id': Relationship(
+            sqlalchemy_model_class=Author,
+            target_name='author',
+            target_identifier_column='author_id',
+            source_foreign_key_column='hated_author_id',
+            lazy=True,
+            nullable=True,
+        ),
     },
     identifier_column_name='author_id',
     relationship_keys=[
         'books',
         'favourite_book',
         'collaborations',
+        'favourite_of',
+        'favourite_author',
+        'hated_by',
+        'hated_author',
     ],
     property_keys=[
         'author_id',
@@ -31,6 +50,8 @@ author = DomainModel(
     json_translation_map={
         'author_id': 'id',
         'book_id': 'favourite_book',
+        'favourite_author_id': 'favourite_author',
+        'hated_author_id': 'hated_author',
     },
     eager_relationships=[
         'books',

--- a/bookshop/domain/Book.py
+++ b/bookshop/domain/Book.py
@@ -1,9 +1,8 @@
 from bookshop.domain.types import DomainModel, Relationship
 
 
-from bookshop.sqlalchemy.model.Author import Author
-from bookshop.sqlalchemy.model.Author import Author
 from bookshop.sqlalchemy.model.Review import Review
+from bookshop.sqlalchemy.model.Author import Author
 from bookshop.sqlalchemy.model.Genre import Genre
 
 book = DomainModel(

--- a/bookshop/sqlalchemy/model/Author.py
+++ b/bookshop/sqlalchemy/model/Author.py
@@ -6,28 +6,57 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class Author(db.Model):  # type: ignore
+    # Properties
     id =                  db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
     author_id =           db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
     name =                db.Column(db.String, index=True, nullable=False)  # noqa: E501
     favourite_author_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
     hated_author_id =     db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
-    books =               db.relationship(
+
+    # Relationships
+    books = db.relationship(
         'Book',
         lazy=False,
         uselist=True,
         foreign_keys='Book.author_id',
     )
-    favourite_book =      db.relationship(
+    favourite_book = db.relationship(
         'Book',
         lazy=False,
         uselist=False,
         foreign_keys='Book.author_id',
     )
-    collaborations =      db.relationship(
+    collaborations = db.relationship(
         'Book',
         lazy=False,
         uselist=True,
         foreign_keys='Book.collaborator_id',
+    )
+    favourite_of = db.relationship(
+        'Author',
+        lazy=True,
+        uselist=True,
+        foreign_keys=[favourite_author_id],
+    )
+    favourite_author = db.relationship(
+        'Author',
+        lazy=True,
+        uselist=False,
+        primaryjoin=id==favourite_author_id,
+        remote_side=[id],
+    )
+    hated_by = db.relationship(
+        'Author',
+        lazy=True,
+        uselist=True,
+        foreign_keys=[hated_author_id],
+    )
+    hated_author = db.relationship(
+        'Author',
+        lazy=True,
+        uselist=False,
+        primaryjoin=id==hated_author_id,
+        remote_side=[id],
     )
 
     __table_args__ = (UniqueConstraint('author_id', ), )

--- a/bookshop/sqlalchemy/model/Book.py
+++ b/bookshop/sqlalchemy/model/Book.py
@@ -6,6 +6,7 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class Book(db.Model):  # type: ignore
+    # Properties
     id =              db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
     book_id =         db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
     name =            db.Column(db.String, index=True, nullable=False)  # noqa: E501
@@ -14,24 +15,26 @@ class Book(db.Model):  # type: ignore
     collaborator_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
     published =       db.Column(db.Date, nullable=True)  # noqa: E501
     created =         db.Column(db.DateTime, nullable=True)  # noqa: E501
-    author =          db.relationship(
+
+    # Relationships
+    author = db.relationship(
         'Author',
         lazy=False,
         uselist=False,
         foreign_keys=[author_id],
     )
-    collaborator =    db.relationship(
+    collaborator = db.relationship(
         'Author',
         lazy=False,
         uselist=False,
         foreign_keys=[collaborator_id],
     )
-    reviews =         db.relationship(
+    reviews = db.relationship(
         'Review',
         lazy=True,
         uselist=True,
     )
-    genre =           db.relationship(
+    genre = db.relationship(
         'Genre',
         lazy=False,
         uselist=False,

--- a/bookshop/sqlalchemy/model/BookGenre.py
+++ b/bookshop/sqlalchemy/model/BookGenre.py
@@ -6,17 +6,20 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class BookGenre(db.Model):  # type: ignore
+    # Properties
     id =            db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
     book_genre_id = db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
     book_id =       db.Column(db.BigInteger, db.ForeignKey('book.id'), nullable=True)  # noqa: E501
     genre_id =      db.Column(db.BigInteger, db.ForeignKey('genre.id'), nullable=True)  # noqa: E501
-    book =          db.relationship(
+
+    # Relationships
+    book = db.relationship(
         'Book',
         lazy=False,
         uselist=False,
         foreign_keys=[book_id],
     )
-    genre =         db.relationship(
+    genre = db.relationship(
         'Genre',
         lazy=False,
         uselist=False,

--- a/bookshop/sqlalchemy/model/Genre.py
+++ b/bookshop/sqlalchemy/model/Genre.py
@@ -6,10 +6,13 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class Genre(db.Model):  # type: ignore
+    # Properties
     id =       db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
     genre_id = db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
     title =    db.Column(db.String, nullable=True)  # noqa: E501
-    book =     db.relationship(
+
+    # Relationships
+    book = db.relationship(
         'Book',
         lazy=False,
         uselist=True,

--- a/bookshop/sqlalchemy/model/Review.py
+++ b/bookshop/sqlalchemy/model/Review.py
@@ -6,11 +6,14 @@ from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
 
 class Review(db.Model):  # type: ignore
+    # Properties
     id =        db.Column(BigIntegerVariantType, primary_key=True, autoincrement=True)  # noqa: E501
     review_id = db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
     text =      db.Column(db.String, index=True, nullable=False)  # noqa: E501
     book_id =   db.Column(db.BigInteger, db.ForeignKey('book.id'), nullable=True)  # noqa: E501
-    book =      db.relationship(
+
+    # Relationships
+    book = db.relationship(
         'Book',
         lazy=False,
         uselist=False,

--- a/genyrator/entities/Template.py
+++ b/genyrator/entities/Template.py
@@ -117,6 +117,12 @@ class DomainModel(Template):
     entity:      Entity = attr.ib()
     module_name: str =    attr.ib()
 
+    def sqlalchemy_model_imports(self):
+        return list(set([
+            rel.target_entity_class_name
+            for rel in self.entity.relationships
+        ]))
+
 
 @attr.s
 class ConvertProperties(Template):

--- a/genyrator/templates/domain/domain_model.j2
+++ b/genyrator/templates/domain/domain_model.j2
@@ -1,7 +1,7 @@
 from {{ template.module_name }}.domain.types import DomainModel, Relationship
 
-{% for relationship in template.entity.relationships %}
-from {{ template.module_name }}.sqlalchemy.model.{{ relationship.target_entity_class_name }} import {{ relationship.target_entity_class_name }}
+{% for target_entity_class_name in template.sqlalchemy_model_imports() %}
+from {{ template.module_name }}.sqlalchemy.model.{{ target_entity_class_name }} import {{ target_entity_class_name }}
 {%- endfor %}
 
 {{ template.entity.python_name }} = DomainModel(

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -12,7 +12,9 @@ from {{ template.module_name }}.sqlalchemy.model.types import BigIntegerVariantT
 class {{ template.entity.class_name }}(db.Model):  # type: ignore
 {%- if template.entity.table_name %}
     __table_name__ = '{{ template.entity.table_name }}'
-{% endif -%}
+
+{% endif %}
+    # Properties
 {%- if template.entity.additional_properties %}
     {%- for property in template.entity.additional_properties %}
     {{ property.python_name }} = {{ property.value }}
@@ -27,18 +29,29 @@ class {{ template.entity.class_name }}(db.Model):  # type: ignore
     {%- if column.index %}, index=True{% endif %}{# -#}
     , nullable={{ column.nullable | string }})  # noqa: E501
 {%- endfor %}
+
+    # Relationships
 {%- for relationship in template.entity.relationships %}
-    {{ relationship.property_name }} ={{ pad(relationship.property_name) }} db.relationship(
+    {{ relationship.property_name }} = db.relationship(
         '{{ relationship.target_entity_class_name }}',
         lazy={{ relationship.lazy | string }},
         uselist={{ relationship.join.value == 'to_many' | string }},
-    {%- if relationship.source_foreign_key_column_name %}
+    {%- if relationship.target_entity_class_name == template.entity.class_name -%}
+      {%- if relationship.source_foreign_key_column_name %}
+        primaryjoin=id=={{ relationship.source_foreign_key_column_name }},
+        remote_side=[id],
+      {%- elif relationship.target_foreign_key_column_name %}
+        foreign_keys=[{{ relationship.target_foreign_key_column_name }}],
+      {%- endif -%}
+    {%- else -%}
+      {%- if relationship.source_foreign_key_column_name %}
         foreign_keys=[{{ relationship.source_foreign_key_column_name }}],
-    {%- elif relationship.target_foreign_key_column_name %}
+      {%- elif relationship.target_foreign_key_column_name %}
         foreign_keys='{{ relationship.target_entity_class_name }}.{{ relationship.target_foreign_key_column_name }}',
-    {%- endif %}
-    {%- if relationship.__class__.__name__ == 'RelationshipWithJoinTable' %}
+      {%- endif %}
+      {%- if relationship.__class__.__name__ == 'RelationshipWithJoinTable' %}
         secondary='{{ relationship.join_table }}',
+      {%- endif %}
     {%- endif %}
     )
 {%- endfor %}

--- a/test/e2e/features/sqlalchemy_relationships.feature
+++ b/test/e2e/features/sqlalchemy_relationships.feature
@@ -3,14 +3,14 @@ Feature: SQLAlchemy relationships
   Background:
     Given I have the example "bookshop" application
 
-  Scenario: Following a 1-to-many relationship
+  Scenario: Following a to-many relationship
     Given I put an example "author" entity
       And I put a book entity with a relationship to that author
       And I put a book entity with a relationship to that author
      When I get that "author" SQLAlchemy model
      Then "sql_author.books" should have "2" items in it
   
-  Scenario: Following a many-to-1 relationship
+  Scenario: Following a to-1 relationship
     Given I put an example "author" entity
       And I put a book entity with a relationship to that author
       And I put a book entity with a relationship to that author
@@ -18,10 +18,25 @@ Feature: SQLAlchemy relationships
      Then "sql_book.author" should be that author
       And "sql_book.collaborator" should be None
 
-  Scenario: Following other many-to-1 relationship
+  Scenario: Following other to-1 relationship
     Given I put an example "author" entity
       And I put a book entity with a relationship to that author
       And I also put a collaborator relationship to that author
      When I get that "book" SQLAlchemy model
      Then "sql_book.author" should be that author
       And "sql_book.collaborator" should be that author
+
+  Scenario: Following self referencing to-1 relationship
+    Given I put an example "author" entity called "author1"
+      And I put an example "author" entity called "author2" with a "favouriteAuthorId" from "author1"
+     When I get the "author" called "author2" SQLAlchemy model
+     Then "sql_author.favourite_author" should be "author1"
+      And "sql_author.hated_author" should be None
+
+  Scenario: Following a self referencing to-many relationship
+    Given I put an example "author" entity called "author1"
+      And I put an example "author" entity called "author2" with a "favouriteAuthorId" from "author1"
+      And I put an example "author" entity called "author3" with a "favouriteAuthorId" from "author1"
+      When I get the "author" called "author1" SQLAlchemy model
+      Then "sql_author.favourite_author" should be None
+       And "sql_author.favourite_of" should have "2" items in it


### PR DESCRIPTION
This handles the case when there are multiple relationships from the same entity back on itself. This situation needs to be handled specially because SQLAlchemy doesn't know which join path to use.

See: https://docs.sqlalchemy.org/en/latest/orm/join_conditions.html#handling-multiple-join-paths