### PR TITLE
JSON casing eager_relationships

### DIFF
--- a/bookshop/sqlalchemy/model_to_dict.py
+++ b/bookshop/sqlalchemy/model_to_dict.py
@@ -29,7 +29,7 @@ def model_to_dict(
             sqlalchemy_model=sqlalchemy_model,
             paths=paths,
         ),
-        **eager_relationships,
+        **python_dict_to_json_dict(eager_relationships),
     }
 
 


### PR DESCRIPTION
This just makes sure that the eager relationships are JSON cased, otherwise they would come out as python dictionaries by default.