### PR TITLE
default fixture fakers

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2019 jumblesale
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/genyrator/entities/Schema.py
+++ b/genyrator/entities/Schema.py
@@ -32,6 +32,10 @@ class Schema(object):
         for model in self.files.db_models:
             model.write()
 
+    def write_fixtures(self):
+        for model in self.files.fixtures:
+            model.write()
+
     def write_core_files(self):
         for core_file in self.files.core:
             core_file.write()

--- a/genyrator/templates/sqlalchemy/fixture/fixture.j2
+++ b/genyrator/templates/sqlalchemy/fixture/fixture.j2
@@ -1,6 +1,5 @@
 {%- set entity = template.entity -%}
 import factory
-import uuid
 
 from {{ template.db_import_path }} import db
 from {{ template.module_name }}.sqlalchemy.model.{{ entity.class_name }} import {{ entity.class_name }}
@@ -12,4 +11,10 @@ class {{ entity.class_name }}Factory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session = db.session
 
     {{ entity.identifier_column.python_name }} = factory.Faker('{{ entity.identifier_column.faker_method }}')
+    {%- for column in entity.columns %}
+        {%- if column.python_name != entity.identifier_column.python_name and
+               column.faker_method is not none %}
+    {{ column.python_name }} = factory.Faker('{{ column.faker_method }}')
+        {%- endif %}
+    {%- endfor %}
 

--- a/genyrator/types.py
+++ b/genyrator/types.py
@@ -120,7 +120,7 @@ def type_option_to_default_value(type_option: TypeOption) -> str:
 
 def type_option_to_faker_method(type_option: TypeOption) -> str:
     return {
-        TypeOption.string:   'pystring',
+        TypeOption.string:   'pystr',
         TypeOption.float:    'pyfloat',
         TypeOption.int:      'pyint',
         TypeOption.bool:     'pybool',

--- a/test/e2e/features/fixtures.feature
+++ b/test/e2e/features/fixtures.feature
@@ -10,11 +10,22 @@ Feature: Creating fixtures from SQLAlchemy models
       And I write that schema
       And I import the generated app
       And I initialize the database
-     When I create a fixture for the "Book" entity with values
-    """
-    {
-      "title": "always coming home",
-      "rating": 7.2
-    }
-    """
+     When I create a fixture for the "Book" entity
+     Then the db contains "1" "Book" entity
+
+  Scenario: Creating a fixture with all the types
+    Given I have an entity "Book" with properties
+      | name      | type     |
+      | title     | str      |
+      | rating    | float    |
+      | published | date     |
+      | created   | datetime |
+      | count     | int      |
+      | in_stock  | bool     |
+      And identifier column "book_id" with type "UUID"
+      And I create a schema from those entities
+      And I write that schema
+      And I import the generated app
+      And I initialize the database
+     When I create a fixture for the "Book" entity
      Then the db contains "1" "Book" entity

--- a/test/e2e/steps/generated_app_steps.py
+++ b/test/e2e/steps/generated_app_steps.py
@@ -229,14 +229,13 @@ def step_impl(context):
     """)
 
 
-@when('I create a fixture for the "{entity_name}" entity with values')
+@when('I create a fixture for the "{entity_name}" entity')
 def step_impl(context, entity_name: str):
     fixture_module_name = f'{context.module_name}.sqlalchemy.fixture.{entity_name}'
     fixture_module = importlib.import_module(fixture_module_name)
     fixture = getattr(fixture_module, f'{entity_name}Factory')
-    args = json.loads(context.text)
     with context.app.app_context():
-        fixture.create(**args)
+        instance = fixture.create()
         context.generated_module.db.session.commit()
 
 


### PR DESCRIPTION
* updated licence
* added method to write fixture files from schema
* added default `faker_method` to columns which have no `faker_method`, but which are not nullable. this lets you always just use a generated factory to build your fixtures. currently only supports primitives - lists and dicts are painful, and why are you creating them non-nullable anyway