### PR TITLE
Feature/join entity map by

### DIFF
--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -14,7 +14,6 @@ from bookshop.sqlalchemy.model import Author
 from bookshop.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
 from bookshop.schema import AuthorSchema
 from bookshop.sqlalchemy.model_to_dict import model_to_dict
 from bookshop.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -14,7 +14,6 @@ from bookshop.sqlalchemy.model import Book
 from bookshop.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
 from bookshop.schema import BookSchema
 from bookshop.sqlalchemy.model_to_dict import model_to_dict
 from bookshop.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/bookshop/resources/BookGenre.py
+++ b/bookshop/resources/BookGenre.py
@@ -14,7 +14,6 @@ from bookshop.sqlalchemy.model import BookGenre
 from bookshop.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
 from bookshop.schema import BookGenreSchema
 from bookshop.sqlalchemy.model_to_dict import model_to_dict
 from bookshop.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/bookshop/resources/Genre.py
+++ b/bookshop/resources/Genre.py
@@ -14,7 +14,6 @@ from bookshop.sqlalchemy.model import Genre
 from bookshop.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
 from bookshop.schema import GenreSchema
 from bookshop.sqlalchemy.model_to_dict import model_to_dict
 from bookshop.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/bookshop/resources/RelatedBook.py
+++ b/bookshop/resources/RelatedBook.py
@@ -14,7 +14,6 @@ from bookshop.sqlalchemy.model import RelatedBook
 from bookshop.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
 from bookshop.schema import RelatedBookSchema
 from bookshop.sqlalchemy.model_to_dict import model_to_dict
 from bookshop.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/bookshop/resources/Review.py
+++ b/bookshop/resources/Review.py
@@ -14,7 +14,6 @@ from bookshop.sqlalchemy.model import Review
 from bookshop.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
 from bookshop.schema import ReviewSchema
 from bookshop.sqlalchemy.model_to_dict import model_to_dict
 from bookshop.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/bookshop/sqlalchemy/convert_dict_to_marshmallow_result.py
+++ b/bookshop/sqlalchemy/convert_dict_to_marshmallow_result.py
@@ -8,7 +8,7 @@ from bookshop.sqlalchemy import db
 from bookshop.core.convert_dict import json_dict_to_python_dict
 from bookshop.domain.types import DomainModel
 from bookshop.sqlalchemy.convert_properties import convert_properties_to_sqlalchemy_properties
-from bookshop.sqlalchemy.join_entities import create_joined_entity_map
+from bookshop.sqlalchemy.join_entities import create_joined_entity_id_map
 
 
 def convert_dict_to_marshmallow_result(
@@ -27,17 +27,17 @@ def convert_dict_to_marshmallow_result(
     if patch_data is not None:
         data = {**data, **patch_data}
 
-    joined_entities_or_errors = create_joined_entity_map(
+    joined_entity_ids_or_errors = create_joined_entity_id_map(
         domain_model,
         data,
     )
 
-    if isinstance(joined_entities_or_errors, list):
-        return joined_entities_or_errors
+    if isinstance(joined_entity_ids_or_errors, list):
+        return joined_entity_ids_or_errors
 
     data = convert_properties_to_sqlalchemy_properties(
         domain_model,
-        joined_entities_or_errors,
+        joined_entity_ids_or_errors,
         json_dict_to_python_dict(data),
     )
 

--- a/bookshop/sqlalchemy/convert_properties.py
+++ b/bookshop/sqlalchemy/convert_properties.py
@@ -7,7 +7,7 @@ from bookshop.domain.types import DomainModel
 
 def convert_properties_to_sqlalchemy_properties(
         model:           DomainModel,
-        joined_entities: Mapping[str, DeclarativeMeta],
+        joined_entities: Mapping[str, int],
         data:            Mapping[str, Any],
 ) -> Mapping[str, Any]:
     result = {}
@@ -17,7 +17,7 @@ def convert_properties_to_sqlalchemy_properties(
             result[model.identifier_column_name] = data[k]
         elif k in joined_entities:
             entity = joined_entities[k]
-            result[model.external_identifier_map[k].source_foreign_key_column] = getattr(entity, 'id')
+            result[model.external_identifier_map[k].source_foreign_key_column] = entity
         else:
             result[k] = v
     return result

--- a/bookshop/sqlalchemy/join_entities.py
+++ b/bookshop/sqlalchemy/join_entities.py
@@ -4,7 +4,7 @@ from bookshop.core.convert_case import to_json_name
 from bookshop.domain.types import DomainModel
 
 
-def create_joined_entity_map(
+def create_joined_entity_id_map(
     domain_model: DomainModel,
     data:         Mapping[str, Any]
 ) -> Union[List[str], Mapping[str, Any]]:
@@ -16,7 +16,11 @@ def create_joined_entity_map(
             continue
         target_identifier_value = data[json_relationship_name]
         filter_kwargs = {relationship.target_identifier_column: target_identifier_value}
-        result = relationship.sqlalchemy_model_class.query.filter_by(**filter_kwargs).first()
+        result = relationship.sqlalchemy_model_class \
+                .query \
+                .with_entities(relationship.sqlalchemy_model_class.id) \
+                .filter_by(**filter_kwargs) \
+                .first()
         if relationship.nullable is False and result is None and target_identifier_value is not None:
             errors.append(
                 [f'Could not find {relationship.target_name} with {json_relationship_name} equal to {target_identifier_value}']
@@ -24,5 +28,5 @@ def create_joined_entity_map(
         elif relationship.nullable is True and result is None:
             continue
         else:
-            joined_entities[external_identifier] = result
+            joined_entities[external_identifier] = result[0]
     return joined_entities if not errors else errors

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -28,7 +28,6 @@ from {{ template.db_import_path }} import db
 from {{ template.module_name }}.sqlalchemy.convert_properties import (
     convert_properties_to_sqlalchemy_properties, convert_sqlalchemy_properties_to_dict_properties
 )
-from {{ template.module_name }}.sqlalchemy.join_entities import create_joined_entity_map
 from {{ template.module_name }}.schema import {{ entity.class_name }}Schema
 from {{ template.module_name }}.sqlalchemy.model_to_dict import model_to_dict
 from {{ template.module_name }}.sqlalchemy.convert_dict_to_marshmallow_result import convert_dict_to_marshmallow_result

--- a/genyrator/templates/sqlalchemy/convert_dict_to_marshmallow_result.j2
+++ b/genyrator/templates/sqlalchemy/convert_dict_to_marshmallow_result.j2
@@ -8,7 +8,7 @@ from {{ template.db_import_path }} import db
 from {{ template.module_name }}.core.convert_dict import json_dict_to_python_dict
 from {{ template.module_name }}.domain.types import DomainModel
 from {{ template.module_name }}.sqlalchemy.convert_properties import convert_properties_to_sqlalchemy_properties
-from {{ template.module_name }}.sqlalchemy.join_entities import create_joined_entity_map
+from {{ template.module_name }}.sqlalchemy.join_entities import create_joined_entity_id_map
 
 
 def convert_dict_to_marshmallow_result(
@@ -27,17 +27,17 @@ def convert_dict_to_marshmallow_result(
     if patch_data is not None:
         data = {**data, **patch_data}
 
-    joined_entities_or_errors = create_joined_entity_map(
+    joined_entity_ids_or_errors = create_joined_entity_id_map(
         domain_model,
         data,
     )
 
-    if isinstance(joined_entities_or_errors, list):
-        return joined_entities_or_errors
+    if isinstance(joined_entity_ids_or_errors, list):
+        return joined_entity_ids_or_errors
 
     data = convert_properties_to_sqlalchemy_properties(
         domain_model,
-        joined_entities_or_errors,
+        joined_entity_ids_or_errors,
         json_dict_to_python_dict(data),
     )
 

--- a/genyrator/templates/sqlalchemy/convert_properties.j2
+++ b/genyrator/templates/sqlalchemy/convert_properties.j2
@@ -7,7 +7,7 @@ from {{ template.module_name }}.domain.types import DomainModel
 
 def convert_properties_to_sqlalchemy_properties(
         model:           DomainModel,
-        joined_entities: Mapping[str, DeclarativeMeta],
+        joined_entities: Mapping[str, int],
         data:            Mapping[str, Any],
 ) -> Mapping[str, Any]:
     result = {}
@@ -17,7 +17,7 @@ def convert_properties_to_sqlalchemy_properties(
             result[model.identifier_column_name] = data[k]
         elif k in joined_entities:
             entity = joined_entities[k]
-            result[model.external_identifier_map[k].source_foreign_key_column] = getattr(entity, 'id')
+            result[model.external_identifier_map[k].source_foreign_key_column] = entity
         else:
             result[k] = v
     return result

--- a/genyrator/templates/sqlalchemy/join_entities.j2
+++ b/genyrator/templates/sqlalchemy/join_entities.j2
@@ -4,7 +4,7 @@ from {{ template.module_name }}.core.convert_case import to_json_name
 from {{ template.module_name }}.domain.types import DomainModel
 
 
-def create_joined_entity_map(
+def create_joined_entity_id_map(
     domain_model: DomainModel,
     data:         Mapping[str, Any]
 ) -> Union[List[str], Mapping[str, Any]]:
@@ -16,7 +16,11 @@ def create_joined_entity_map(
             continue
         target_identifier_value = data[json_relationship_name]
         filter_kwargs = {relationship.target_identifier_column: target_identifier_value}
-        result = relationship.sqlalchemy_model_class.query.filter_by(**filter_kwargs).first()
+        result = relationship.sqlalchemy_model_class \
+                .query \
+                .with_entities(relationship.sqlalchemy_model_class.id) \
+                .filter_by(**filter_kwargs) \
+                .first()
         if relationship.nullable is False and result is None and target_identifier_value is not None:
             errors.append(
                 [f'Could not find {relationship.target_name} with {json_relationship_name} equal to {target_identifier_value}']
@@ -24,6 +28,6 @@ def create_joined_entity_map(
         elif relationship.nullable is True and result is None:
             continue
         else:
-            joined_entities[external_identifier] = result
+            joined_entities[external_identifier] = result[0]
     return joined_entities if not errors else errors
 


### PR DESCRIPTION
The joined entity map is only every used for the id. Hydrating the whole
entity is often very expensive, especially for large entities. This
change makes the joined entity map just load the id.