### PR TITLE
Create joined entity map on posts, allowing us to post relationships

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ mamba:
 	pipenv run mamba test
 
 pep8:
-	pipenv run pycodestyle
+	pipenv run pycodestyle genyrator
 
 bookshop-build:
 	pipenv run python bookshop.py

--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -152,15 +152,25 @@ class ManyAuthorResource(Resource):  # type: ignore
 
         data['authorId'] = uuid.uuid4()
 
-        marshmallow_result = author_schema.load(json_dict_to_python_dict(data), session=db.session)
-        if marshmallow_result.errors:
-            abort(400, marshmallow_result.errors)
+        marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
+            data=json_dict_to_python_dict(data),
+            identifier=data['authorId'],
+            identifier_column='author_id',
+            domain_model=author_domain_model,
+            sqlalchemy_model=Author,
+            schema=author_schema,
+            )
 
-        db.session.add(marshmallow_result.data)
+        if isinstance(marshmallow_schema_or_errors, list):
+            abort(400, marshmallow_schema_or_errors)
+        if marshmallow_schema_or_errors.errors:
+            abort(400, marshmallow_schema_or_errors)
+
+        db.session.add(marshmallow_schema_or_errors.data)
         db.session.commit()
 
         return python_dict_to_json_dict(model_to_dict(
-            marshmallow_result.data,
+            marshmallow_schema_or_errors.data,
         )), 201
 
 

--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -153,13 +153,13 @@ class ManyAuthorResource(Resource):  # type: ignore
         data['authorId'] = uuid.uuid4()
 
         marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
-            data=json_dict_to_python_dict(data),
+            data=data,
             identifier=data['authorId'],
             identifier_column='author_id',
             domain_model=author_domain_model,
             sqlalchemy_model=Author,
             schema=author_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -165,13 +165,13 @@ class ManyBookResource(Resource):  # type: ignore
         data['bookId'] = uuid.uuid4()
 
         marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
-            data=json_dict_to_python_dict(data),
+            data=data,
             identifier=data['bookId'],
             identifier_column='book_id',
             domain_model=book_domain_model,
             sqlalchemy_model=Book,
             schema=book_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -164,15 +164,25 @@ class ManyBookResource(Resource):  # type: ignore
 
         data['bookId'] = uuid.uuid4()
 
-        marshmallow_result = book_schema.load(json_dict_to_python_dict(data), session=db.session)
-        if marshmallow_result.errors:
-            abort(400, marshmallow_result.errors)
+        marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
+            data=json_dict_to_python_dict(data),
+            identifier=data['bookId'],
+            identifier_column='book_id',
+            domain_model=book_domain_model,
+            sqlalchemy_model=Book,
+            schema=book_schema,
+            )
 
-        db.session.add(marshmallow_result.data)
+        if isinstance(marshmallow_schema_or_errors, list):
+            abort(400, marshmallow_schema_or_errors)
+        if marshmallow_schema_or_errors.errors:
+            abort(400, marshmallow_schema_or_errors)
+
+        db.session.add(marshmallow_schema_or_errors.data)
         db.session.commit()
 
         return python_dict_to_json_dict(model_to_dict(
-            marshmallow_result.data,
+            marshmallow_schema_or_errors.data,
         )), 201
 
 

--- a/bookshop/resources/BookGenre.py
+++ b/bookshop/resources/BookGenre.py
@@ -154,7 +154,7 @@ class ManyBookGenreResource(Resource):  # type: ignore
             domain_model=book_genre_domain_model,
             sqlalchemy_model=BookGenre,
             schema=book_genre_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/bookshop/resources/BookGenre.py
+++ b/bookshop/resources/BookGenre.py
@@ -147,13 +147,23 @@ class ManyBookGenreResource(Resource):  # type: ignore
 
         data['bookGenreId'] = uuid.uuid4()
 
-        marshmallow_result = book_genre_schema.load(json_dict_to_python_dict(data), session=db.session)
-        if marshmallow_result.errors:
-            abort(400, marshmallow_result.errors)
+        marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
+            data=data,
+            identifier=data['bookGenreId'],
+            identifier_column='book_genre_id',
+            domain_model=book_genre_domain_model,
+            sqlalchemy_model=BookGenre,
+            schema=book_genre_schema,
+            )
 
-        db.session.add(marshmallow_result.data)
+        if isinstance(marshmallow_schema_or_errors, list):
+            abort(400, marshmallow_schema_or_errors)
+        if marshmallow_schema_or_errors.errors:
+            abort(400, marshmallow_schema_or_errors)
+
+        db.session.add(marshmallow_schema_or_errors.data)
         db.session.commit()
 
         return python_dict_to_json_dict(model_to_dict(
-            marshmallow_result.data,
+            marshmallow_schema_or_errors.data,
         )), 201

--- a/bookshop/resources/Genre.py
+++ b/bookshop/resources/Genre.py
@@ -143,13 +143,13 @@ class ManyGenreResource(Resource):  # type: ignore
         data['genreId'] = uuid.uuid4()
 
         marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
-            data=json_dict_to_python_dict(data),
+            data=data,
             identifier=data['genreId'],
             identifier_column='genre_id',
             domain_model=genre_domain_model,
             sqlalchemy_model=Genre,
             schema=genre_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/bookshop/resources/Genre.py
+++ b/bookshop/resources/Genre.py
@@ -142,13 +142,23 @@ class ManyGenreResource(Resource):  # type: ignore
 
         data['genreId'] = uuid.uuid4()
 
-        marshmallow_result = genre_schema.load(json_dict_to_python_dict(data), session=db.session)
-        if marshmallow_result.errors:
-            abort(400, marshmallow_result.errors)
+        marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
+            data=json_dict_to_python_dict(data),
+            identifier=data['genreId'],
+            identifier_column='genre_id',
+            domain_model=genre_domain_model,
+            sqlalchemy_model=Genre,
+            schema=genre_schema,
+            )
 
-        db.session.add(marshmallow_result.data)
+        if isinstance(marshmallow_schema_or_errors, list):
+            abort(400, marshmallow_schema_or_errors)
+        if marshmallow_schema_or_errors.errors:
+            abort(400, marshmallow_schema_or_errors)
+
+        db.session.add(marshmallow_schema_or_errors.data)
         db.session.commit()
 
         return python_dict_to_json_dict(model_to_dict(
-            marshmallow_result.data,
+            marshmallow_schema_or_errors.data,
         )), 201

--- a/bookshop/resources/RelatedBook.py
+++ b/bookshop/resources/RelatedBook.py
@@ -147,13 +147,23 @@ class ManyRelatedBookResource(Resource):  # type: ignore
 
         data['relatedBookUuid'] = uuid.uuid4()
 
-        marshmallow_result = related_book_schema.load(json_dict_to_python_dict(data), session=db.session)
-        if marshmallow_result.errors:
-            abort(400, marshmallow_result.errors)
+        marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
+            data=json_dict_to_python_dict(data),
+            identifier=data['relatedBookUuid'],
+            identifier_column='related_book_uuid',
+            domain_model=related_book_domain_model,
+            sqlalchemy_model=RelatedBook,
+            schema=related_book_schema,
+            )
 
-        db.session.add(marshmallow_result.data)
+        if isinstance(marshmallow_schema_or_errors, list):
+            abort(400, marshmallow_schema_or_errors)
+        if marshmallow_schema_or_errors.errors:
+            abort(400, marshmallow_schema_or_errors)
+
+        db.session.add(marshmallow_schema_or_errors.data)
         db.session.commit()
 
         return python_dict_to_json_dict(model_to_dict(
-            marshmallow_result.data,
+            marshmallow_schema_or_errors.data,
         )), 201

--- a/bookshop/resources/RelatedBook.py
+++ b/bookshop/resources/RelatedBook.py
@@ -148,13 +148,13 @@ class ManyRelatedBookResource(Resource):  # type: ignore
         data['relatedBookUuid'] = uuid.uuid4()
 
         marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
-            data=json_dict_to_python_dict(data),
+            data=data,
             identifier=data['relatedBookUuid'],
             identifier_column='related_book_uuid',
             domain_model=related_book_domain_model,
             sqlalchemy_model=RelatedBook,
             schema=related_book_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/bookshop/resources/Review.py
+++ b/bookshop/resources/Review.py
@@ -147,13 +147,13 @@ class ManyReviewResource(Resource):  # type: ignore
         data['reviewId'] = uuid.uuid4()
 
         marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
-            data=json_dict_to_python_dict(data),
+            data=data,
             identifier=data['reviewId'],
             identifier_column='review_id',
             domain_model=review_domain_model,
             sqlalchemy_model=Review,
             schema=review_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -186,7 +186,7 @@ class Many{{ entity.class_name }}Resource(Resource):  # type: ignore
         {% endif %}
 
         marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
-            data=json_dict_to_python_dict(data),
+            data=data,
             identifier=data['{{ entity.identifier_column.json_property_name }}'],
             identifier_column='{{ entity.identifier_column.python_name }}',
             domain_model={{ template.entity.python_name }}_domain_model,

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -185,15 +185,25 @@ class Many{{ entity.class_name }}Resource(Resource):  # type: ignore
         abort(400, {'message': 'Cannot auto-generate non-UUID identifiers'})
         {% endif %}
 
-        marshmallow_result = {{ entity.python_name }}_schema.load(json_dict_to_python_dict(data), session=db.session)
-        if marshmallow_result.errors:
-            abort(400, marshmallow_result.errors)
+        marshmallow_schema_or_errors = convert_dict_to_marshmallow_result(
+            data=json_dict_to_python_dict(data),
+            identifier=data['{{ entity.identifier_column.json_property_name }}'],
+            identifier_column='{{ entity.identifier_column.python_name }}',
+            domain_model={{ template.entity.python_name }}_domain_model,
+            sqlalchemy_model={{ entity.class_name }},
+            schema={{ entity.python_name }}_schema,
+            )
 
-        db.session.add(marshmallow_result.data)
+        if isinstance(marshmallow_schema_or_errors, list):
+            abort(400, marshmallow_schema_or_errors)
+        if marshmallow_schema_or_errors.errors:
+            abort(400, marshmallow_schema_or_errors)
+
+        db.session.add(marshmallow_schema_or_errors.data)
         db.session.commit()
 
         return python_dict_to_json_dict(model_to_dict(
-            marshmallow_result.data,
+            marshmallow_schema_or_errors.data,
         )), 201
 
     {%- endif -%}{# support post #}

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -192,7 +192,7 @@ class Many{{ entity.class_name }}Resource(Resource):  # type: ignore
             domain_model={{ template.entity.python_name }}_domain_model,
             sqlalchemy_model={{ entity.class_name }},
             schema={{ entity.python_name }}_schema,
-            )
+        )
 
         if isinstance(marshmallow_schema_or_errors, list):
             abort(400, marshmallow_schema_or_errors)

--- a/test/e2e/features/joined_entity_operations.feature
+++ b/test/e2e/features/joined_entity_operations.feature
@@ -6,7 +6,7 @@ Feature: Posting new entities with foreign keys
   Scenario: Putting a join entity
     Given I put an example "book" entity
       And I put an example "genre" entity
-     When I put a "book_genre" join entity
+     When I "put" a "book_genre" join entity
      Then I can see that genre in the response from "book/{id}/genres"
 
   Scenario: Putting a join entity where the join does not exist
@@ -31,3 +31,10 @@ Feature: Posting new entities with foreign keys
       And I patch that "book" entity with that "author" id
      When I patch that "book" entity to set "name" to "dave dave dave: the dave story"
      Then I can see that "book" has "name" set to "dave dave dave: the dave story"
+
+  Scenario: POSTing a join entity
+    Given I put an example "book" entity
+      And I put an example "genre" entity
+     When I "post" a "book_genre" join entity
+     Then I can see that genre in the response from "book/{id}/genres"
+

--- a/test/e2e/steps/bookshop_steps.py
+++ b/test/e2e/steps/bookshop_steps.py
@@ -96,16 +96,20 @@ def _put_entity(context, entity_type: str, entity_name: str, extras: Mapping[str
     assert_that(response.status_code, equal_to(201))
 
 
-@when('I put a "book_genre" join entity')
-def step_impl(context):
+@when('I "{verb}" a "book_genre" join entity')
+def step_impl(context, verb):
     book_uuid =  context.book_entity['id']
     genre_uuid = context.genre_entity['id']
     book_genre_entity = generate_example_book_genre(
         book_uuid=book_uuid, genre_uuid=genre_uuid,
     )
     context.book_genre_uuid = book_genre_uuid = book_genre_entity['id']
-    response = make_request(client=context.client, endpoint=f'book-genre/{book_genre_uuid}',
-                            method='put', data=book_genre_entity)
+    if verb.lower() == 'put':
+        response = make_request(client=context.client, endpoint=f'book-genre/{book_genre_uuid}',
+                                method=verb, data=book_genre_entity)
+    elif verb.lower() == 'post':
+        response = make_request(client=context.client, endpoint=f'book-genre',
+                                method=verb, data=book_genre_entity)
     assert_that(response.status_code, equal_to(201))
 
 


### PR DESCRIPTION
Currently, post only allows us to create a single entity as we do not construct the "joined entity map" from the payload in the request.

Also only pycodestyle the `genyrator` directory as it was checking all the dependencies for me.