### PR TITLE
use sqlalchemy core json type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
 install:
   - pip install pipenv
   - pipenv install --dev
+  - pipenv graph
 script:
   - make test

--- a/Pipfile
+++ b/Pipfile
@@ -4,32 +4,29 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-attrs = ">=18.1"
-inflection = ">=0.3"
-factory-boy = "*"
-jinja2 = "*"
-sqlalchemy = "==1.3.0b2"
+attrs = "~=18.1"
+inflection = "~=0.3"
+factory-boy = "~=2.11"
+jinja2 = "~=2.10"
+sqlalchemy = "~=1.3.0b2"
+marshmallow = "~=2.18"
 
 [dev-packages]
-behave = "*"
-flask = "*"
-flask-marshmallow = "*"
-flask-restplus = "*"
-flask-sqlalchemy = "*"
-marshmallow-sqlalchemy = "*"
-pycodestyle = "*"
-pyhamcrest = "*"
-python-dateutil = "*"
-sqlalchemy = "*"
-twine = "*"
-mamba = "*"
-expects = "*"
-sqlalchemy-utils = "*"
+behave = "~=1.2"
+flask = "~=1.0"
+flask-marshmallow = "~=0.9"
+flask-restplus = "~=0.12"
+flask-sqlalchemy = "~=2.3"
+marshmallow-sqlalchemy = "~=0.15"
+pycodestyle = "~=2.5"
+pyhamcrest = "~=1.9"
+python-dateutil = "~=2.7"
+twine = "~=1.12"
+mamba = "~=0.10"
+expects = "~=0.9"
+sqlalchemy-utils = "~=0.33"
 pipenv = "*"
-ipdb = "*"
+ipdb = "~=0.11"
 
 [requires]
 python_version = "3.6"
-
-[pipenv]
-allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ attrs = ">=18.1"
 inflection = ">=0.3"
 factory-boy = "*"
 jinja2 = "*"
+sqlalchemy = "==1.3.0b2"
 
 [dev-packages]
 behave = "*"
@@ -29,3 +30,6 @@ ipdb = "*"
 
 [requires]
 python_version = "3.6"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b238f3f1261cf80ff9b0cc5327e77b95cb9d4f48fdd791b04f0b4b8e314d29d1"
+            "sha256": "5e74e8c8733553ae762175c0142ce954dcc63e582807032b5dbde4b23b5380a9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -86,6 +86,14 @@
                 "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
             "version": "==1.1.0"
+        },
+        "marshmallow": {
+            "hashes": [
+                "sha256:958e6640bec9a04ca15701e3d99b12c4269d0f43be596f00eeca1f2baf530abc",
+                "sha256:d072db26baf2b0de886ad58f12360610d7bdea439e975a0179d1da82340c4f72"
+            ],
+            "index": "pypi",
+            "version": "==2.18.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -392,10 +400,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:313836a251e67d2ef06631f3bddfffdd7d1c5b16b4efc76244afa6218c5e17b0",
-                "sha256:c850c60dbb840860f58f161b81ae25cf84807eeae3f9a1d9a2f8c704d6bd2b80"
+                "sha256:958e6640bec9a04ca15701e3d99b12c4269d0f43be596f00eeca1f2baf530abc",
+                "sha256:d072db26baf2b0de886ad58f12360610d7bdea439e975a0179d1da82340c4f72"
             ],
-            "version": "==3.0.0rc3"
+            "index": "pypi",
+            "version": "==2.18.0"
         },
         "marshmallow-sqlalchemy": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ae2f20a0b8209e4c055683c5ef61255530d64615dc99cbdb05d45cf360ce4399"
+            "sha256": "b238f3f1261cf80ff9b0cc5327e77b95cb9d4f48fdd791b04f0b4b8e314d29d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -101,6 +101,13 @@
             ],
             "version": "==1.12.0"
         },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:c08cee353acaa05dd4ddf8ae0b0844ae779ed88e0b0784a2c9e0c0f9118eb64c"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0b2"
+        },
         "text-unidecode": {
             "hashes": [
                 "sha256:5a1375bb2ba7968740508ae38d92e1f889a0832913cb1c447d5e2046061a396d",
@@ -117,11 +124,27 @@
             ],
             "version": "==4.1.0"
         },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "args": {
             "hashes": [
                 "sha256:a785b8d837625e9b61c39108532d95b85274acd679693b71ebb5156848fcf814"
             ],
             "version": "==0.1.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "index": "pypi",
+            "version": "==18.2.0"
         },
         "backcall": {
             "hashes": [
@@ -174,39 +197,47 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:029c69deaeeeae1b15bc6c59f0ffa28aa8473721c614a23f2c2976dec245cd12",
+                "sha256:02abbbebc6e9d5abe13cd28b5e963dedb6ffb51c146c916d17b18f141acd9947",
+                "sha256:0384e4479aeb780bfb811eb54c3deb37dbc5e197cd19ec1190cb4b33b254f661",
+                "sha256:1bbfe5b82a3921d285e999c6d256c1e16b31c554c29da62d326f86c173d30337",
+                "sha256:20bbeef0d08e43ef44e10d5863225e178fe100d5778c616260286202bad9d2b4",
+                "sha256:210c02f923df33a8d0e461c86fdcbbb17228ff4f6d92609fc06370a98d283c2d",
+                "sha256:2d0807ba935f540d20b49d5bf1c0237b90ce81e133402feda906e540003f2f7a",
+                "sha256:35d7a013874a7c927ce997350d314144ffc5465faf787bb4e46e6c4f381ef562",
+                "sha256:3636f9d0dcb01aed4180ef2e57a4e34bb4cac3ecd203c2a23db8526d86ab2fb4",
+                "sha256:42f4be770af2455a75e4640f033a82c62f3fb0d7a074123266e143269d7010ef",
+                "sha256:48440b25ba6cda72d4c638f3a9efa827b5b87b489c96ab5f4ff597d976413156",
+                "sha256:494fc6f09b776668cb0d69df5caefb9b90867bd280eb1bd004a63c79fbb09e71",
+                "sha256:4dac8dfd1acf6a3ac657475dfdc66c621f291b1b7422a939cc33c13ac5356473",
+                "sha256:4e8474771c69c2991d5eab65764289a7dd450bbea050bc0ebb42b678d8222b42",
+                "sha256:551f10ddfeff56a1325e5a34eff304c5892aa981fd810babb98bfee77ee2fb17",
+                "sha256:5b104982f1809c1577912519eb249f17d9d7e66304ad026666cb60a5ef73309c",
+                "sha256:5c62aef73dfc87bfcca32cee149a1a7a602bc74bac72223236b0023543511c88",
+                "sha256:633151f8d1ad9467b9f7e90854a7f46ed8f2919e8bc7d98d737833e8938fc081",
+                "sha256:772207b9e2d5bf3f9d283b88915723e4e92d9a62c83f44ec92b9bd0cd685541b",
+                "sha256:7d5e02f647cd727afc2659ec14d4d1cc0508c47e6cfb07aea33d7aa9ca94d288",
+                "sha256:8edc25c1449bdf31acfe183e579bb9c75cec59b55220ccefb6a4f960807ef1d0",
+                "sha256:96d895fba9ed55286368bd4626b8dcbf19b9a529a88e5a6b5c22e0b08c95852a",
+                "sha256:a77589fec63dc7fa6469d8cd122cc285ec034be43d8a2ba600020ddb14277514",
+                "sha256:a9798a4111abb0f94584000ba2a2c74841f2cfe5f9254709756367aabbae0541",
+                "sha256:b33a8f3d6d8946ea1db4ec228606ebc45cf880a7b1d1a26fe8790af677c12b8b",
+                "sha256:b38ea741ab9e35bfa7015c93c93bbd6a1623428f97a67083fc8ebd366238b91f",
+                "sha256:b6a5478c904236543c0347db8a05fac6fc0bd574c870e7970faa88e1d9890044",
+                "sha256:c6248bfc1de36a3844685a2e10ba17c18119ba6252547f921062a323fb31bff1",
+                "sha256:c6c6f84282d3f8953072295ce5cb96cdc56c91f164ef451a5c03be8abb84ad56",
+                "sha256:c705ab445936457359b1424ef25ccc0098b0491b26064677c39f1d14a539f056",
+                "sha256:d95a363d663ceee647291131dbd213af258df24f41350246842481ec3709bd33",
+                "sha256:e27265eb80cdc5dab55a40ef6f890e04ecc618649ad3da5265f128b141f93f78",
+                "sha256:eb62a45b448258bd8b9faa2d12dc2b942259715d7e0d85ebbb3d737be83091d7",
+                "sha256:ebc276c9cb5d917bd2ae959f84ffc279acafa9c9b50b0fa436ebb70bbe2166ea",
+                "sha256:f05a38b77b6c62cff204b0874034d76709769b53a8a7fc5886e02fc4d099d540",
+                "sha256:f4d229866d030863d0fe3bf297d6d11e6133ca15bbb41ed2534a8b9a3d6bd061",
+                "sha256:f95675bd88b51474d4fe5165f3266f419ce754ffadfb97f10323931fa9ac95e5",
+                "sha256:f95bc54fb6d61b9f9ff09c4ae8ff6a3f5edc937cda3ca36fc937302a7c152bf1",
+                "sha256:fd0f6be53de40683584e5331c341e65a679dbe5ec489a0697cec7c2ef1a48cda"
             ],
-            "version": "==4.5.2"
+            "version": "==5.0a4"
         },
         "decorator": {
             "hashes": [
@@ -281,7 +312,6 @@
                 "sha256:6a9496209b76463f1dec126ab928919aaf1f55b38beb9219af3fe202f6bbdd12",
                 "sha256:f69932b1e806b38a7818d9a1e918e5821b685715040b48e59c657b3c7961b742"
             ],
-            "markers": "python_version >= '3.3'",
             "version": "==7.2.0"
         },
         "ipython-genutils": {
@@ -315,10 +345,10 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
-                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+                "sha256:683fe7ed58763ea0be572de5aad47cd3cc1297640916f9a8ccd222b287da7d2f",
+                "sha256:b42d7a292addb57370e6260bcbadb77e00a899fe6ec998c453f45893c41c658b"
             ],
-            "version": "==2.6.0"
+            "version": "==3.0.0b3"
         },
         "mamba": {
             "hashes": [
@@ -362,10 +392,10 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:958e6640bec9a04ca15701e3d99b12c4269d0f43be596f00eeca1f2baf530abc",
-                "sha256:d072db26baf2b0de886ad58f12360610d7bdea439e975a0179d1da82340c4f72"
+                "sha256:313836a251e67d2ef06631f3bddfffdd7d1c5b16b4efc76244afa6218c5e17b0",
+                "sha256:c850c60dbb840860f58f161b81ae25cf84807eeae3f9a1d9a2f8c704d6bd2b80"
             ],
-            "version": "==2.18.0"
+            "version": "==3.0.0rc3"
         },
         "marshmallow-sqlalchemy": {
             "hashes": [
@@ -428,11 +458,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:c1d6aff5252ab2ef391c2fe498ed8c088066f66bc64a8d5c095bbf795d9fec34",
-                "sha256:d4c47f79b635a0e70b84fdb97ebd9a274203706b1ee5ed44c10da62755cf3ec9",
-                "sha256:fd17048d8335c1e6d5ee403c3569953ba3eb8555d710bfc548faf0712666ea39"
+                "sha256:88002cc618cacfda8760c4539e76c3b3f148ecdb7035a3d422c7ecdc90c2a3ba",
+                "sha256:c6655a12e9b08edb8cf5aeab4815fd1e1bdea4ad73d3bbf269cf2e0c4eb75d5e",
+                "sha256:df5835fb8f417aa55e5cafadbaeb0cf630a1e824aad16989f9f0493e679ec010"
             ],
-            "version": "==2.0.7"
+            "version": "==2.0.8"
         },
         "ptyprocess": {
             "hashes": [
@@ -443,11 +473,11 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
-                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "pygments": {
             "hashes": [
@@ -459,10 +489,19 @@
         "pyhamcrest": {
             "hashes": [
                 "sha256:6b672c02fdf7470df9674ab82263841ce8333fb143f32f021f6cb26f0e512420",
-                "sha256:8ffaa0a53da57e89de14ced7185ac746227a8894dbd5a3c718bf05ddbd1d56cd"
+                "sha256:7a4bdade0ed98c699d728191a058a60a44d2f9c213c51e2dd1e6fb42f2c6128a",
+                "sha256:8ffaa0a53da57e89de14ced7185ac746227a8894dbd5a3c718bf05ddbd1d56cd",
+                "sha256:bac0bea7358666ce52e3c6c85139632ed89f115e9af52d44b3c36e0bf8cf16a9",
+                "sha256:f30e9a310bcc1808de817a92e95169ffd16b60cbc5a016a49c8d0e8ababfae79"
             ],
             "index": "pypi",
             "version": "==1.9.0"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:5a3827d57ad3e46820e5ee4ed5b9e0ee7bc4686df6634a7368bc1863a5c48a77"
+            ],
+            "version": "==0.14.9"
         },
         "python-dateutil": {
             "hashes": [
@@ -494,10 +533,10 @@
         },
         "requests-toolbelt": {
             "hashes": [
-                "sha256:42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237",
-                "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
             ],
-            "version": "==0.8.0"
+            "version": "==0.9.1"
         },
         "six": {
             "hashes": [
@@ -508,10 +547,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:6af3ca2f7f00844465ab4fa78337d487b39e53f516c51328aed4ed3a719d4264"
+                "sha256:c08cee353acaa05dd4ddf8ae0b0844ae779ed88e0b0784a2c9e0c0f9118eb64c"
             ],
             "index": "pypi",
-            "version": "==1.2.16"
+            "version": "==1.3.0b2"
         },
         "sqlalchemy-utils": {
             "hashes": [
@@ -522,10 +561,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:b856be5cb6cfaee3b2733655c7c5bbc7751291bb5d1a4f54f020af4727570b3e",
-                "sha256:c9b9b5eeba13994a4c266aae7eef7aeeb0ba2973e431027e942b4faea139ef49"
+                "sha256:13f018038711256ed27aae118a80d63929588e90f00d072a0f4eb7aa3333b4dc",
+                "sha256:dd60ea2567baa013c625153ce41fd274209c69a5814513e1d635f20e5cd61b97"
             ],
-            "version": "==4.29.1"
+            "version": "==4.30.0"
         },
         "traitlets": {
             "hashes": [
@@ -551,10 +590,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:34b9ae3742abed2f95d3970acf4d80533261d6061b51160b197f84e5b4c98b4c",
-                "sha256:fa736831a7b18bd2bfeef746beb622a92509e9733d645952da136b0639cd40cd"
+                "sha256:58c359370401e0af817fb0070911e599c5fdc836166306b04fd0f278151ed125",
+                "sha256:729f0bcab430e4ef137646805b5b1d8efbb43fe53d4a0f33328624a84a5121f7"
             ],
-            "version": "==16.2.0"
+            "version": "==16.3.0"
         },
         "virtualenv-clone": {
             "hashes": [

--- a/bookshop/core/convert_dict.py
+++ b/bookshop/core/convert_dict.py
@@ -44,7 +44,9 @@ def json_dict_to_python_dict(json_dict: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 def dict_value_to_json_value(param: Any, fn: Callable[[str], str]) -> Any:
-    if isinstance(param, dict):
+    if isinstance(param, UserJson):
+        return param
+    elif isinstance(param, dict):
         return convert_dict_naming(param, fn)
     elif isinstance(param, (list, set)):
         return convert_iterable_naming(param, fn)

--- a/bookshop/sqlalchemy/convert_dict_to_marshmallow_result.py
+++ b/bookshop/sqlalchemy/convert_dict_to_marshmallow_result.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import noload
 
 from bookshop.sqlalchemy import db
 from bookshop.core.convert_dict import json_dict_to_python_dict
-from bookshop.domain.types import DomainModel
+from bookshop.domain.types import DomainModel, UserJson
 from bookshop.sqlalchemy.convert_properties import convert_properties_to_sqlalchemy_properties
 from bookshop.sqlalchemy.join_entities import create_joined_entity_id_map
 
@@ -38,7 +38,7 @@ def convert_dict_to_marshmallow_result(
     data = convert_properties_to_sqlalchemy_properties(
         domain_model,
         joined_entity_ids_or_errors,
-        json_dict_to_python_dict(data),
+        json_dict_to_python_dict(preserve_user_json(data)),
     )
 
     if result is not None:
@@ -52,3 +52,19 @@ def convert_dict_to_marshmallow_result(
     )
 
     return marshmallow_result
+
+
+def preserve_user_json(
+        data:         Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Convert any dicts provided to UserJSON so that
+    they do not get their case changed when the rest
+    of the data is converted to jsonCase
+    """
+    out_dict = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            out_dict[k] = UserJson(v)
+        else:
+            out_dict[k] = v
+    return out_dict

--- a/bookshop/sqlalchemy/model/Author.py
+++ b/bookshop/sqlalchemy/model/Author.py
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType

--- a/bookshop/sqlalchemy/model/Book.py
+++ b/bookshop/sqlalchemy/model/Book.py
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType

--- a/bookshop/sqlalchemy/model/BookGenre.py
+++ b/bookshop/sqlalchemy/model/BookGenre.py
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType

--- a/bookshop/sqlalchemy/model/Genre.py
+++ b/bookshop/sqlalchemy/model/Genre.py
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType

--- a/bookshop/sqlalchemy/model/RelatedBook.py
+++ b/bookshop/sqlalchemy/model/RelatedBook.py
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType

--- a/bookshop/sqlalchemy/model/Review.py
+++ b/bookshop/sqlalchemy/model/Review.py
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType

--- a/bookshop/sqlalchemy/model_to_dict.py
+++ b/bookshop/sqlalchemy/model_to_dict.py
@@ -3,7 +3,7 @@ from typing import List, Mapping, MutableMapping, Any, Optional, Union
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.collections import InstrumentedList
 
-from bookshop.domain.types import DomainModel
+from bookshop.domain.types import DomainModel, UserJson
 from bookshop.sqlalchemy.convert_between_models import convert_sqlalchemy_model_to_domain_model
 
 
@@ -74,7 +74,6 @@ def _serialize_data(
             serialized_data[dict_key] = UserJson(value)
         else:
             serialized_data[dict_key] = value
-        serialized_data[dict_key] = value
     return serialized_data
 
 

--- a/genyrator/templates/core/convert_dict.j2
+++ b/genyrator/templates/core/convert_dict.j2
@@ -44,7 +44,9 @@ def json_dict_to_python_dict(json_dict: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 def dict_value_to_json_value(param: Any, fn: Callable[[str], str]) -> Any:
-    if isinstance(param, dict):
+    if isinstance(param, UserJson):
+        return param
+    elif isinstance(param, dict):
         return convert_dict_naming(param, fn)
     elif isinstance(param, (list, set)):
         return convert_iterable_naming(param, fn)

--- a/genyrator/templates/sqlalchemy/convert_dict_to_marshmallow_result.j2
+++ b/genyrator/templates/sqlalchemy/convert_dict_to_marshmallow_result.j2
@@ -6,7 +6,7 @@ from sqlalchemy.orm import noload
 
 from {{ template.db_import_path }} import db
 from {{ template.module_name }}.core.convert_dict import json_dict_to_python_dict
-from {{ template.module_name }}.domain.types import DomainModel
+from {{ template.module_name }}.domain.types import DomainModel, UserJson
 from {{ template.module_name }}.sqlalchemy.convert_properties import convert_properties_to_sqlalchemy_properties
 from {{ template.module_name }}.sqlalchemy.join_entities import create_joined_entity_id_map
 
@@ -38,7 +38,7 @@ def convert_dict_to_marshmallow_result(
     data = convert_properties_to_sqlalchemy_properties(
         domain_model,
         joined_entity_ids_or_errors,
-        json_dict_to_python_dict(data),
+        json_dict_to_python_dict(preserve_user_json(data)),
     )
 
     if result is not None:
@@ -52,4 +52,20 @@ def convert_dict_to_marshmallow_result(
     )
 
     return marshmallow_result
+
+
+def preserve_user_json(
+        data:         Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Convert any dicts provided to UserJSON so that
+    they do not get their case changed when the rest
+    of the data is converted to jsonCase
+    """
+    out_dict = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            out_dict[k] = UserJson(v)
+        else:
+            out_dict[k] = v
+    return out_dict
 

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -1,5 +1,6 @@
-from sqlalchemy_utils import UUIDType, JSONType
+from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.types import JSON as JSONType
 
 from {{ template.db_import_path }} import db
 from {{ template.module_name }}.sqlalchemy.model.types import BigIntegerVariantType

--- a/genyrator/templates/sqlalchemy/model_to_dict.j2
+++ b/genyrator/templates/sqlalchemy/model_to_dict.j2
@@ -3,7 +3,7 @@ from typing import List, Mapping, MutableMapping, Any, Optional, Union
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm.collections import InstrumentedList
 
-from {{ template.module_name }}.domain.types import DomainModel
+from {{ template.module_name }}.domain.types import DomainModel, UserJson
 from {{ template.module_name }}.sqlalchemy.convert_between_models import convert_sqlalchemy_model_to_domain_model
 
 
@@ -74,7 +74,6 @@ def _serialize_data(
             serialized_data[dict_key] = UserJson(value)
         else:
             serialized_data[dict_key] = value
-        serialized_data[dict_key] = value
     return serialized_data
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(
     install_requires=[
         'attrs>=18.1',
         'inflection>=0.3',
+        'sqlalchemy==1.3.0b2',
     ],
 )

--- a/test/e2e/environment.py
+++ b/test/e2e/environment.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import shutil
 
 from genyrator.path import get_root_path_list
 
@@ -15,5 +16,4 @@ def before_feature(context, feature):
     # make very sure this is the directory which the command is being run in
     files = glob.glob(os.path.join(*root_path, 'output', '*'))
     for f in files:
-        # shutil.rmtree(f)
-        ...
+        shutil.rmtree(f)

--- a/test/e2e/features/single_entity_operations.feature
+++ b/test/e2e/features/single_entity_operations.feature
@@ -7,6 +7,7 @@ Feature: performing operations on a simple schema
     | publish_date | date     | False    |
     | in_stock     | int      | False    |
     | rating       | float    | True     |
+    | document     | dict     | True     |
     And identifier column "book_id" with type "int"
     And I create a schema "books" from those entities
     And the app is running
@@ -17,7 +18,8 @@ Feature: performing operations on a simple schema
       "bookName": "the dispossessed",
       "publishDate": "1974-05-21",
       "inStock": 3,
-      "rating": 11.6
+      "rating": 11.6,
+      "document": {}
     }
     """
 
@@ -46,7 +48,8 @@ Feature: performing operations on a simple schema
       "bookName": 3,
       "publishDate": "hello",
       "inStock": null,
-      "rating": "5"
+      "rating": "5",
+      "document": {}
     }
     """
     When I make a "PUT" request to "/book-store/3" with that json data
@@ -60,7 +63,31 @@ Feature: performing operations on a simple schema
       "bookName": "the dispossessed",
       "publishDate": "1974-05-21",
       "inStock": 3,
-      "rating": null
+      "rating": null,
+      "document": null
+    }
+    """
+    When I make a "PUT" request to "/book-store/3" with that json data
+    Then I get http status "201"
+     And I can get entity "/book-store/3"
+     And that response matches the original data
+
+  Scenario: creating an entity with json properties
+    Given I have json data
+    """
+    {
+      "id": 3,
+      "bookName": "the dispossessed",
+      "publishDate": "1974-05-21",
+      "inStock": 3,
+      "rating": null,
+      "document": {
+        "chapters": [
+          {"title": "chapter 1", "summary": "not very much happens"},
+          {"title": "chapter 2", "summary": "our hero enters the forest", "my_notes": "trite"},
+          {"title": "chapter 3", "summary": "our hero returns with the boon to humanity", "rating": 3.1}
+        ]
+      }
     }
     """
     When I make a "PUT" request to "/book-store/3" with that json data
@@ -77,7 +104,8 @@ Feature: performing operations on a simple schema
         "bookName": "the disposssesssed",
         "publishDate": "1974-05-22",
         "inStock": 2,
-        "rating": 12.4
+        "rating": 12.4,
+        "document": {}
       }
       """
      When I make a "PUT" request to "/book-store/3" with that json data

--- a/test/e2e/features/single_entity_operations.feature
+++ b/test/e2e/features/single_entity_operations.feature
@@ -85,7 +85,7 @@ Feature: performing operations on a simple schema
         "chapters": [
           {"title": "chapter 1", "summary": "not very much happens"},
           {"title": "chapter 2", "summary": "our hero enters the forest", "my_notes": "trite"},
-          {"title": "chapter 3", "summary": "our hero returns with the boon to humanity", "rating": 3.1}
+          {"title": "chapter 3", "summary": "our hero returns with the boon to humanity", "myRating": 3.1}
         ]
       }
     }


### PR DESCRIPTION
* made dict columns use the core sqlalchemy type instead of the sqlalchemy utils one
* bumped sqlalchemy dependency to **beta** `1.3.0b2`
* user dicts now get munged into `UserJson` on the way in - this prevents it from getting its keys cases changed during `json_dict_to_python_dict`.
  * I don't like this solution very much