### PR TITLE
Add custom SQLAlchemy column options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,4 @@ RUN pip install pipenv && \
     pipenv install --system && \
     pipenv sync --dev
 
-ENV PATH /root/.local/share/virtualenvs/genyrator-oIyKmRQj/bin:$PATH
-
 CMD ["make", "test"]

--- a/bookshop.py
+++ b/bookshop.py
@@ -41,6 +41,16 @@ book_entity = create_entity(
         ),
         create_column(
             name='created', type_option=TypeOption.datetime,
+            sqlalchemy_options={
+                'server_default': 'text(\'CURRENT_TIMESTAMP\')',
+            },
+        ),
+        create_column(
+            name='updated', type_option=TypeOption.datetime,
+            sqlalchemy_options={
+                'default': 'datetime.datetime.utcnow',
+                'onupdate': 'datetime.datetime.utcnow',
+            },
         ),
     ],
     relationships=[

--- a/bookshop/domain/Book.py
+++ b/bookshop/domain/Book.py
@@ -41,6 +41,7 @@ book = DomainModel(
         'collaborator_id',
         'published',
         'created',
+        'updated',
     ],
     json_translation_map={
         'book_id': 'id',

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -31,6 +31,7 @@ book_model = api.model('Book', {
     'collaboratorId': fields.String(),
     'published': fields.Date(),
     'created': fields.DateTime(),
+    'updated': fields.DateTime(),
     'author': fields.Raw(),
     'collaborator': fields.Raw(),
     'genre': fields.Raw(),
@@ -152,6 +153,9 @@ class ManyBookResource(Resource):  # type: ignore
         param_created = request.args.get('created')
         if param_created:
             query = query.filter_by(created=param_created)
+        param_updated = request.args.get('updated')
+        if param_updated:
+            query = query.filter_by(updated=param_updated)
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/bookshop/sqlalchemy/model/Author.py
+++ b/bookshop/sqlalchemy/model/Author.py
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 

--- a/bookshop/sqlalchemy/model/Book.py
+++ b/bookshop/sqlalchemy/model/Book.py
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 
@@ -15,7 +19,8 @@ class Book(db.Model):  # type: ignore
     author_id =       db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
     collaborator_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
     published =       db.Column(db.Date, nullable=True)  # noqa: E501
-    created =         db.Column(db.DateTime, nullable=True)  # noqa: E501
+    created =         db.Column(db.DateTime, server_default=text('CURRENT_TIMESTAMP'), nullable=True)  # noqa: E501
+    updated =         db.Column(db.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=True)  # noqa: E501
 
     # Relationships
     author = db.relationship(

--- a/bookshop/sqlalchemy/model/BookGenre.py
+++ b/bookshop/sqlalchemy/model/BookGenre.py
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 

--- a/bookshop/sqlalchemy/model/Genre.py
+++ b/bookshop/sqlalchemy/model/Genre.py
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 

--- a/bookshop/sqlalchemy/model/RelatedBook.py
+++ b/bookshop/sqlalchemy/model/RelatedBook.py
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 

--- a/bookshop/sqlalchemy/model/Review.py
+++ b/bookshop/sqlalchemy/model/Review.py
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from bookshop.sqlalchemy import db
 from bookshop.sqlalchemy.model.types import BigIntegerVariantType
 

--- a/genyrator/entities/Column.py
+++ b/genyrator/entities/Column.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, NamedTuple
+from typing import Optional, Union, NamedTuple, List, Tuple, Dict
 import attr
 from genyrator.inflector import pythonize, to_class_name, to_json_case, humanize
 from genyrator.types import (
@@ -16,19 +16,20 @@ ForeignKeyRelationship = NamedTuple(
 
 @attr.s
 class Column(object):
-    python_name:        str =                  attr.ib()
-    class_name:         str =                  attr.ib()
-    display_name:       str =                  attr.ib()
-    alias:              str =                  attr.ib()
-    json_property_name: str =                  attr.ib()
-    type_option:        TypeOption =           attr.ib()
-    faker_method:       str =                  attr.ib()
-    sqlalchemy_type:    SqlAlchemyTypeOption = attr.ib()
-    python_type:        PythonTypeOption =     attr.ib()
-    restplus_type:      RestplusTypeOption =   attr.ib()
-    default:            str =                  attr.ib()
-    index:              bool =                 attr.ib()
-    nullable:           bool =                 attr.ib()
+    python_name:        str =                   attr.ib()
+    class_name:         str =                   attr.ib()
+    display_name:       str =                   attr.ib()
+    alias:              str =                   attr.ib()
+    json_property_name: str =                   attr.ib()
+    type_option:        TypeOption =            attr.ib()
+    faker_method:       str =                   attr.ib()
+    sqlalchemy_type:    SqlAlchemyTypeOption =  attr.ib()
+    python_type:        PythonTypeOption =      attr.ib()
+    restplus_type:      RestplusTypeOption =    attr.ib()
+    default:            str =                   attr.ib()
+    index:              bool =                  attr.ib()
+    nullable:           bool =                  attr.ib()
+    sqlalchemy_options: List[Tuple[str, str]] = attr.ib()
 
 
 @attr.s
@@ -52,6 +53,7 @@ def create_column(
         alias:                    Optional[str] = None,
         foreign_key_relationship: Optional[ForeignKeyRelationship] = None,
         faker_method:             Optional[str] = None,
+        sqlalchemy_options:       Optional[Dict[str, str]] = None,
 ) -> Union[Column, ForeignKey]:
     """Return a column to be attached to an entity
 
@@ -77,6 +79,8 @@ def create_column(
         faker_method: The method to pass to Faker to provide fixture data for this column.
                       If this column is not nullable, defaults to the constructor for the type
                       of this column.
+
+        sqlalchemy_options: Pass additional keyword arguments to the SQLAlchemy column object.
     """
     if identifier is True:
         constructor = IdentifierColumn
@@ -87,6 +91,9 @@ def create_column(
 
     if faker_method is None and nullable is False:
         faker_method = type_option_to_faker_method(type_option)
+
+    if sqlalchemy_options is None:
+        sqlalchemy_options = {}
 
     args = {
         "python_name":        pythonize(name),
@@ -102,6 +109,7 @@ def create_column(
         "nullable":           nullable,
         "alias":              alias,
         "faker_method":       faker_method,
+        "sqlalchemy_options": [(key, value) for key, value in sqlalchemy_options.items()],
     }
     if foreign_key_relationship is not None:
         args['relationship'] = '{}.{}'.format(

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -2,6 +2,10 @@ from sqlalchemy_utils import UUIDType
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.types import JSON as JSONType
 
+# Available for custom sqlalchemy_options
+import datetime
+from sqlalchemy import text
+
 from {{ template.db_import_path }} import db
 from {{ template.module_name }}.sqlalchemy.model.types import BigIntegerVariantType
 
@@ -28,6 +32,11 @@ class {{ template.entity.class_name }}(db.Model):  # type: ignore
     {{ column.sqlalchemy_type.value }}{# -#}
     {%- if column.relationship is defined %}, db.ForeignKey('{{ column.relationship }}'){% endif %}
     {%- if column.index %}, index=True{% endif %}{# -#}
+    {%- if column.sqlalchemy_options -%}
+      {%- for option, value in column.sqlalchemy_options -%}
+      , {{ option }}={{ value }}
+      {%- endfor -%}
+    {%- endif -%}
     , nullable={{ column.nullable | string }})  # noqa: E501
 {%- endfor %}
 

--- a/test/e2e/features/sqlalchemy_column_options.feature
+++ b/test/e2e/features/sqlalchemy_column_options.feature
@@ -1,0 +1,19 @@
+Feature: Custom SQLAlchemy column options
+
+  Background:
+    Given I have the example "bookshop" application
+
+  Scenario: Column defaults are correctly applied
+    Given I put an example "book" entity
+     When I get that "book" SQLAlchemy model
+     Then "sql_book.created" should be a recent timestamp
+      And "sql_book.updated" should be a recent timestamp
+
+  Scenario: Column onupdate rules are correctly applied
+    Given I put an example "book" entity
+     When I get that "book" SQLAlchemy model
+      And I save the value of "sql_book.updated" as "original_updated"
+      And I patch that "book" entity to set "name" to "cave"
+      And I get that "book" SQLAlchemy model
+     Then "sql_book.updated" should not equal saved value "original_updated"
+


### PR DESCRIPTION
This change allows the client to pass through custom SQLAlchemy column options which will be added to the Column object on the SQLAlchemy model. The specific need that motivated this change was to create `created_at` and `updated_at` datetime fields. As such, this is what has
been used in the tests.