### PR TITLE
deeply merge dicts for model_to_dict

### DIFF
--- a/genyrator/templates/sqlalchemy/model_to_dict.j2
+++ b/genyrator/templates/sqlalchemy/model_to_dict.j2
@@ -23,13 +23,10 @@ def model_to_dict(
             return_immediately=True,
         )
         eager_relationships[relationship] = relationship_dict
-    return {
-        **_model_to_dict(
-            sqlalchemy_model=sqlalchemy_model,
-            paths=paths,
-        ),
-        **eager_relationships,
-    }
+    return dict(deep_merge(
+        _model_to_dict(sqlalchemy_model=sqlalchemy_model,paths=paths),
+        eager_relationships,
+    ))
 
 
 def _model_to_dict(
@@ -99,3 +96,19 @@ def _recurse_on_model_or_list(
             return_immediately=return_immediately,
         )
 
+
+def deep_merge(dict1: Mapping[str, Any], dict2: Mapping[str, Any]):
+    for k in set(dict1.keys()).union(dict2.keys()):
+        if k in dict1 and k in dict2:
+            if isinstance(dict1[k], dict) and isinstance(dict2[k], dict):
+                yield (k, dict(deep_merge(dict1[k], dict2[k])))
+            elif isinstance(dict1[k], list) and isinstance(dict2[k], list):
+                yield (k, list(dict1[k] + dict2[k]))
+            elif isinstance(dict1[k], list) and not isinstance(dict2[k], list):
+                yield (k, dict1[k])
+            else:
+                yield (k, dict2[k])
+        elif k in dict1:
+            yield (k, dict1[k])
+        else:
+            yield (k, dict2[k])


### PR DESCRIPTION
Before, we did not deeply merge dicts that we return from `model_to_dict`.  

This changes that so we now merge the values of the dictionaries and return the union of all the values of all dictionaries.